### PR TITLE
Updated type for transforms and also explicitly stated that ANARI exp…

### DIFF
--- a/chapters/api_concepts.txt
+++ b/chapters/api_concepts.txt
@@ -22,7 +22,7 @@ algorithm.  The <<world>> holds arrays of the drawable objects of the scene such
 as <<surface>>, <<volume>>, and <<light>> either directly or via an array of
 <<instance,Instances>> containing <<group>>. A <<group>> holds arrays of
 <<surface>>, <<volume>>, and <<light>> to be instanced together. An <<instance>>
-combines a <<group>> with a transform to placement of the same collection of
+combines a <<group>> with a transform for placement of the same collection of
 objects at multiple locations within the same <<world>>. A <<surface>>
 represents drawable surfaces containing a <<geometry>> and a <<material>>. A
 <<geometry>> specifies drawable primitives and data associated with them. A

--- a/chapters/object_types/objects_in_world.txt
+++ b/chapters/object_types/objects_in_world.txt
@@ -179,8 +179,8 @@ there are no surfaces, no volumes, or no lights instanced.
 [[instance]]
 === Instance
 
-Instances apply transforms to groups for placement in the World. Instances are
-created with
+Instances apply transforms to groups for placement in the World. All matrix transforms 
+are expected to use a row-major layout. Instances are created with
 
 [source,cpp]
 ....
@@ -195,7 +195,7 @@ instances world-space transform.
 |===================================================================================================
 | Name      | Type           |                                       Default | Description
 | group     |`GROUP`         |                                               | Group to be instanced, required
-| transform |`FLOAT32_MAT3x4`| \((1, 0, 0), (0, 1, 0), (0, 0, 1), (0, 0, 0)) | world-space transformation matrix for all attached objects
+| transform |`FLOAT32_MAT4x3`| \((1, 0, 0), (0, 1, 0), (0, 0, 1), (0, 0, 0)) | world-space transformation matrix for all attached objects
                                                                                (overridden by  `motion.transform`, <<core_extensions_transformation_motion_blur, extension `KHR_TRANSFORMATION_MOTION_BLUR`>>)
 |===================================================================================================
 
@@ -218,7 +218,7 @@ Camera>> `shutter` also needs to be set appropiately.
 [cols="<2,<2,>,<5",options="header,unbreakable"]
 |===================================================================================================
 | Name               | Type                           | Default | Description
-| motion.transform   |`ARRAY1D` of `FLOAT32_MAT3x4`   |         | additional uniformly distributed world-space transformations
+| motion.transform   |`ARRAY1D` of `FLOAT32_MAT4x3`   |         | additional uniformly distributed world-space transformations
 | motion.scale       |`ARRAY1D` of `FLOAT32_VEC3`     |         | additional uniformly distributed scale, overridden by `motion.transform`
 | motion.rotation    |`ARRAY1D` of `FLOAT32_QUAT_IJKW`|         | additional uniformly distributed quaternion rotation, overridden by `motion.transform`
 | motion.translation |`ARRAY1D` of `FLOAT32_VEC3`     |         | additional uniformly distributed transformlation, overridden by `motion.transform`

--- a/chapters/standard_subtypes/cameras.txt
+++ b/chapters/standard_subtypes/cameras.txt
@@ -6,7 +6,8 @@
 === Cameras
 
 This section outlines camera subtypes which are supplied by complete ANARI
-device implementations.
+device implementations. All matrix transforms are expected to use a row-major
+layout.
 
 All cameras sources accept the following parameters:
 
@@ -18,7 +19,7 @@ All cameras sources accept the following parameters:
 | position               |`FLOAT32_VEC3`|        (0, 0, 0) | position of the camera in world-space
 | direction              |`FLOAT32_VEC3`|       (0, 0, -1) | main viewing direction of the camera
 | up                     |`FLOAT32_VEC3`|        (0, 1, 0) | up direction of the camera
-| transform              |`FLOAT32_MAT3x4`| \((1, 0, 0), (0, 1, 0), (0, 0, 1), (0, 0, 0))
+| transform              |`FLOAT32_MAT4x3`| \((1, 0, 0), (0, 1, 0), (0, 0, 1), (0, 0, 0))
                         | additional world-space transformation matrix (overridden by  `motion.transform`, <<core_extensions_transformation_motion_blur, extension `KHR_TRANSFORMATION_MOTION_BLUR`>>)
 | imageRegion            |`FLOAT32_BOX2`|\((0, 0), (1, 1)) | region of the sensor in normalized screen-space coordinates
 | apertureRadius         |`FLOAT32`     |                0 | size of the aperture, controls the depth of field
@@ -51,7 +52,7 @@ All cameras support depth of field via the `apertureRadius` and
 [cols="<3,<2,>2,<4",options="header,unbreakable"]
 |===================================================================================================
 | Name               | Type                           |    Default | Description
-| motion.transform   |`ARRAY1D` of `FLOAT32_MAT3x4`   |            | additional uniformly distributed world-space transformations
+| motion.transform   |`ARRAY1D` of `FLOAT32_MAT4x3`   |            | additional uniformly distributed world-space transformations
 | motion.scale       |`ARRAY1D` of `FLOAT32_VEC3`     |            | additional uniformly distributed scale, overridden by `motion.transform`
 | motion.rotation    |`ARRAY1D` of `FLOAT32_QUAT_IJKW`|            | additional uniformly distributed quaternion rotation, overridden by `motion.transform`
 | motion.translation |`ARRAY1D` of `FLOAT32_VEC3`     |            | additional uniformly distributed transformlation, overridden by `motion.transform`

--- a/chapters/standard_subtypes/samplers.txt
+++ b/chapters/standard_subtypes/samplers.txt
@@ -6,7 +6,8 @@
 === Samplers
 
 This section outlines sampler subtypes which are supplied by complete ANARI
-device implementations.
+device implementations. All matrix transforms are expected to use a row-major
+layout.
 
 ==== Image1D
 


### PR DESCRIPTION
Updated type for transforms and also explicitly stated that ANARI expects all matrix transforms to use a row-major layout. Fixes #6 