### PR TITLE
Resolves #69 Added 2D transfer function support and updated Volume object type

### DIFF
--- a/chapters/object_types.txt
+++ b/chapters/object_types.txt
@@ -53,6 +53,15 @@ Feature support information can be queried as properties on the `ANARIRenderer`
 |===================================================================================================
 
 
+Feature: `KHR_RENDERER_VOLUME_METHOD`
+
+.Parameters understood by renderers with feature `KHR_RENDERER_VOLUME_METHOD`.
+[cols="<,<,>,<3",options="header,unbreakable"]
+|===================================================================================================
+| Name   | Type   | Default | Description
+| method |`STRING`| raycast | the volume rendering technique, possible values: raycast, splatting, shear-warp, texture 
+|===================================================================================================
+
 Feature: `KHR_RENDERER_BACKGROUND_COLOR`
 
 .Parameters understood by renderers with feature `KHR_RENDERER_BACKGROUND_COLOR`.

--- a/chapters/object_types/volumes.txt
+++ b/chapters/object_types/volumes.txt
@@ -6,23 +6,17 @@
 === Volume
 
 Volumes in ANARI represent volumetric objects (complementing <<Surface,
-surfaces>>), encapsulating spatial data as well as appearance information. To
-create a new volume object of given subtype `subtype` use
+surfaces>>) and take a <<object_types_spatial_field, SpatialField>> which defines the 
+spatial representation. The <<Renderer, renderer>> defines the volume rendering method used for 
+the volume (e.g., ray casting/marching, splatting, shear warp, texture/image-based).
+Volumes are created with
 
 [source,cpp]
 ....
-ANARIVolume anariNewVolume(ANARIDevice, const char *subtype);
+ANARIVolume anariNewVolume(ANARIDevice);
 ....
 
-[[object_types_volume_scivis]]
-==== Scivis
-
-Feature: `KHR_VOLUME_SCIVIS`
-
-The scivis volume is created by passing the subtype string `scivis` to
-`anariNewVolume`. It supports the folowing parameter:
-
-.Parameters understood by the scivis volume.
+.Parameters understood by Volume.
 [cols="<3,<3,>2,<9",options="header,unbreakable"]
 |===================================================================================================
 | Name             | Type                 | Default | Description
@@ -34,6 +28,7 @@ The scivis volume is created by passing the subtype string `scivis` to
 | opacity.position |`ARRAY1D` of `FLOAT32`|         | optional array to position the elements of `opacity` values in `valueRange`
 | densityScale     |`FLOAT32`             |       1 | makes volumes uniformly thinner or thicker
 | id               |`UINT32`              |     -1u | optional user Id, for <<object_types_frame>> channel `objectId`
+| material         |`MATERIAL`            |         | optional <<object_types_material>> to handle volumetric effects like scattering 
 |===================================================================================================
 
 The `color` and the `opacity` array map values sampled in `field`
@@ -60,4 +55,15 @@ be uniformly distributed within `valueRange`, with the first element
 representing the color/opacity of the lowest value in `valueRange`, and
 the last element representing the color/opacity of the last element in
 `valueRange`.
+
+Feature: `KHR_VOLUME_TF2D`: The 2D transfer function look-up table defined by `tf2d` uses field
+values for the columns and gradient magnitude for the rows.
+
+.Additional parameters accepted by the volume with feature `KHR_VOLUME_TF2D`.
+[cols="<3,<3,>2,<9",options="header,unbreakable"]
+|===================================================================================================
+| Name              | Type                            | Default | Description
+| gradient          |`ARRAY1D` of `FLOAT32`           |         | optional array to map gradient magnitude to an opacity multiplier
+| tf2d              |`Sampler` with subtype `image2D` |         | optional 2D image sampler for defining the 2D transfer function look-up table
+|===================================================================================================
 

--- a/chapters/object_types/volumes.txt
+++ b/chapters/object_types/volumes.txt
@@ -63,7 +63,7 @@ values for the columns and gradient magnitude for the rows.
 [cols="<3,<3,>2,<9",options="header,unbreakable"]
 |===================================================================================================
 | Name              | Type                            | Default | Description
-| gradient          |`ARRAY1D` of `FLOAT32`           |         | optional array to map gradient magnitude to an opacity multiplier
+| gradient          |`ARRAY1D` of `FLOAT32_VEC2`      |         | optional array to map gradient magnitude to an opacity multiplier
 | tf2d              |`Sampler` with subtype `image2D` |         | optional 2D image sampler for defining the 2D transfer function look-up table
 |===================================================================================================
 


### PR DESCRIPTION
Resolves #69. Added 2D transfer function support and updated Volume object type by removing **subtype** as it really isn't needed similar to how **subtype** is not needed for the Surface object type. 

Also added a feature to the Renderer for explicitly specifying the volume rendering method.

