### PR TITLE
allow FLOAT64 for TF valueRange parameter

### DIFF
--- a/chapters/object_types/volumes.txt
+++ b/chapters/object_types/volumes.txt
@@ -29,9 +29,7 @@ The 1D transfer function volume is created by passing the subtype string
 | field            |`SPATIAL_FIELD`       |         | <<object_types_spatial_field, Spatial field>> used for the field values of the volume
 | valueRange       |`FLOAT32_BOX1` / `FLOAT64_BOX1` |  [0, 1] | sampled values of `field` are clamped to this range
 | color            |`ARRAY1D` of <<Color>>|         | array to map sampled and clamped field values to color
-| color.position   |`ARRAY1D` of `FLOAT32`|         | optional array to position the elements of `color` values in `valueRange`
 | opacity          |`ARRAY1D` of `FLOAT32`|         | array to map sampled and clamped field values to opacity
-| opacity.position |`ARRAY1D` of `FLOAT32`|         | optional array to position the elements of `opacity` values in `valueRange`
 | densityScale     |`FLOAT32`             |       1 | makes volumes uniformly thinner or thicker
 | id               |`UINT32`              |     -1u | optional user Id, for <<object_types_frame>> channel `objectId`
 |===================================================================================================
@@ -48,16 +46,7 @@ which is used to visually emphasize the structure or certain features in
 the `field` data. Both arrays can be of different size.
 ====
 
-If present, `color.position` and `opacity.position` arrays must contain
-monotonically increasing values within (inclusive) `valueRange` and
-their array size must not be larger than the corresponding `color` or
-`opacity` array. The `*.position` arrays contain the numeric position
-which the elements of corresponding `color` or `opacity` reside within
+The values in the `color` and `opacity` arrays are assumed to be uniformly
+distributed within `valueRange`, with the first element representing the lowest
+value in `valueRange` and the last element representing the the last element in
 `valueRange`.
-
-If a `*.position` array is not set, the position values are assumed to
-be uniformly distributed within `valueRange`, with the first element
-representing the color/opacity of the lowest value in `valueRange`, and
-the last element representing the color/opacity of the last element in
-`valueRange`.
-

--- a/chapters/object_types/volumes.txt
+++ b/chapters/object_types/volumes.txt
@@ -27,7 +27,7 @@ The 1D transfer function volume is created by passing the subtype string
 |===================================================================================================
 | Name             | Type                 | Default | Description
 | field            |`SPATIAL_FIELD`       |         | <<object_types_spatial_field, Spatial field>> used for the field values of the volume
-| valueRange       |`FLOAT32_BOX1`        |  [0, 1] | sampled values of `field` are clamped to this range
+| valueRange       |`FLOAT32_BOX1` / `FLOAT64_BOX1` |  [0, 1] | sampled values of `field` are clamped to this range
 | color            |`ARRAY1D` of <<Color>>|         | array to map sampled and clamped field values to color
 | color.position   |`ARRAY1D` of `FLOAT32`|         | optional array to position the elements of `color` values in `valueRange`
 | opacity          |`ARRAY1D` of `FLOAT32`|         | array to map sampled and clamped field values to opacity


### PR DESCRIPTION
Given that spatial fields can be `FLOAT64`, it makes sense to allow precise clamping behavior on the parent transfer function.

Per the 5/17 WG discussion, position arrays are also removed in favor of adding them only when there exists an ANARI device implementation that will directly use the control-point version of TF colors + opacities (currently none do this).