### PR TITLE
AMR Spatial Field Extension

### DIFF
--- a/appendices/extension_index.txt
+++ b/appendices/extension_index.txt
@@ -53,7 +53,7 @@
 * <<object_types_sampler_image3D, `KHR_SAMPLER_IMAGE3D`>>: `image3D` sampler subtype is supported
 * <<object_types_sampler_primitive, `KHR_SAMPLER_PRIMITIVE`>>: `primitive` sampler subtype is supported
 * <<object_types_sampler_transform, `KHR_SAMPLER_TRANSFORM`>>: `transform` sampler subtype is supported
-* <<object_types_spatial_field_amr, `KHR_SPATIAL_FIELD_AMR`>>: `amr` spatial field subtype is supported
+* <<object_types_spatial_field_block_structured_amr, `KHR_SPATIAL_FIELD_BLOCK_STRUCTURED_AMR`>>: `blockStructuredAmr` spatial field subtype is supported
 * <<object_types_spatial_field_structured_regular, `KHR_SPATIAL_FIELD_STRUCTURED_REGULAR`>>: `structuredRegular` spatial field subtype is supported
 * <<object_types_spatial_field_unstructured, `KHR_SPATIAL_FIELD_UNSTRUCTURED`>>: `unstructured` spatial field subtype is supported
 * <<object_types_volume_transfer_function1d, `KHR_VOLUME_TRANSFER_FUNCTION1D`>>: `transferFunction1D` volume subtype is supported

--- a/appendices/extension_index.txt
+++ b/appendices/extension_index.txt
@@ -53,6 +53,7 @@
 * <<object_types_sampler_image3D, `KHR_SAMPLER_IMAGE3D`>>: `image3D` sampler subtype is supported
 * <<object_types_sampler_primitive, `KHR_SAMPLER_PRIMITIVE`>>: `primitive` sampler subtype is supported
 * <<object_types_sampler_transform, `KHR_SAMPLER_TRANSFORM`>>: `transform` sampler subtype is supported
+* <<object_types_spatial_field_amr, `KHR_SPATIAL_FIELD_AMR`>>: `amr` spatial field subtype is supported
 * <<object_types_spatial_field_structured_regular, `KHR_SPATIAL_FIELD_STRUCTURED_REGULAR`>>: `structuredRegular` spatial field subtype is supported
 * <<object_types_spatial_field_unstructured, `KHR_SPATIAL_FIELD_UNSTRUCTURED`>>: `unstructured` spatial field subtype is supported
 * <<object_types_volume_transfer_function1d, `KHR_VOLUME_TRANSFER_FUNCTION1D`>>: `transferFunction1D` volume subtype is supported

--- a/chapters/object_types/spatial_fields.txt
+++ b/chapters/object_types/spatial_fields.txt
@@ -14,6 +14,47 @@ created with
 ANARISpatialField anariNewSpatialField(ANARIDevice, const char *subtype);
 ....
 
+[[object_types_spatial_field_amr]]
+==== Adaptive Mesh Refinement (AMR)
+
+Extension `KHR_SPATIAL_FIELD_AMR`
+
+Adaptive Mesh Refinement (AMR) spatial fields are created by passing the subtype
+string `amr` to <<object_types_spatial_field, `anariNewSpatialField`>>. The
+parameters understood by AMR spatial fields are summarized in the table below.
+
+.Configuration parameters for AMR spatial fields.
+[cols="<2,<3,>,<4",options="header,unbreakable"]
+|===================================================================================================
+| Name            | Type                    | Default   | Description
+| block.start     |`ARRAY1D` of `INT32_VEC3`| | array of local grid origin, index in voxels, for each AMR block 
+| block.level     |`ARRAY1D` of `UINT32`    | | array of each block's refinement level 
+| block.data      |`ARRAY1D` of `ARRAY3D` of `FIXED8` / `UFIXED8` / `FIXED16` / `UFIXED16` / `FLOAT32` / `FLOAT64` | | array of 3D arrays containing the scalar voxel data 
+| origin          |`FLOAT32_VEC3`           | (0, 0, 0) | origin of the coarsest (virtual) grid in object-space
+| spacing         |`FLOAT32_VEC3`           | (1, 1, 1) | size of the coarsest grid cells at level 0 in object-space
+| refinementRatio |`ARRAY1D` of `UINT32`    | | array of refinement ratios relative to the previous level, for levels > 0
+|===================================================================================================
+
+The AMR block scheme used by this extension is based on the
+Berger-Oliger-Collela scheme which is also used by other toolkits and libraries
+like VTK. The following structure is adopted for this scheme:
+
+* All grids are Cartesian
+* Grids at the same level do not overlap
+* The refinement ratios between adjacent levels are integer and uniform within
+  the same level
+* Grid cells are never partially refined
+
+AMR blocks are defined by three parameters: their start index, the refinement
+level in which they reside, and the scalar data contained within each block. The
+end index of a block can be deduced from its start index and its size (via the
+`ARRAY3D`).
+
+The number of levels is the maximum value in `block.level` plus one. Array
+`refinementRatio` must be at least as large as the number of levels minus one.
+The refinement ratio for level _l_ is stored at index _l-1_ in
+`refinementRatio`.
+
 [[object_types_spatial_field_structured_regular]]
 ==== Structured Regular
 
@@ -109,44 +150,3 @@ the the index order of the cells is the same as their VTK counterparts
 `cell.index` cooresponds to the Offsets array and `index` to the Connectivity
 array of (current, not legacy) `vtkCellArray`.
 ====
-
-[[object_types_spatial_field_amr]]
-==== Adaptive Mesh Refinement 
-
-Extension `KHR_SPATIAL_FIELD_AMR`
-
-Adaptive Mesh Refinement (AMR) spatial fields are created by passing the subtype string
-`amr` to <<object_types_spatial_field, `anariNewSpatialField`>>. The parameters
-understood by AMR spatial fields are summarized in the table below.
-
-.Configuration parameters for AMR spatial fields.
-[cols="<,<2,>,<5",options="header,unbreakable"]
-|===================================================================================================
-| Name         | Type                     | Default   | Description
-| block.data   |`ARRAY1D` of `ARRAY3D` of `FLOAT32` | | array of 3D arrays containing the scalar voxel data 
-| gridOrigin   |`FLOAT32_VEC3`            | (0, 0, 0) | origin of the grid in object-space
-| gridSpacing  |`FLOAT32_VEC3`            | (1, 1, 1) | size of the grid cells in object-space
-| method       |`STRING`                  | `default` | sampling method
-| cellWidth    |`ARRAY1D` of `FLOAT32`    | | array of each level's cell width 
-| block.bounds |`ARRAY1D` of `INT32_BOX3` | | array of grid sizes, in voxels, for each AMR block 
-| block.level  |`ARRAY1D` of `INT32`      | | array of each block's refinement level 
-|===================================================================================================
-
-The AMR block scheme used by this extension is based on the Berger-Oliger-Collela scheme which is also 
-used by other toolkits and libraries like VTK. The following structure is adopted for this scheme:
-
-* All grids are Cartesian
-* Grids at the same level do not overlap
-* The refinement ratios between adjacent levels are integer and uniform within the same level
-* Grid cells are never partially refined
-
-AMR blocks are defined by three parameters: their bounds, the refinement level in which they reside, and
-the scalar data contained within each block. The coarsest refinement level starts at 0 and cell widths are 
-defined per refinement level, not per block.
-
-The `method` parameter determines the interpolation method used when sampling the volume. The `default`
-method uses the back-end's default interpolation technique. Refer to the back-end's documentation for
-details on the default interpolation technique used and other interpolation methods, if any, it supports.
-
-Applications which set unknown values for `method` will result in the default being used.
-

--- a/chapters/object_types/spatial_fields.txt
+++ b/chapters/object_types/spatial_fields.txt
@@ -133,7 +133,7 @@ understood by AMR spatial fields are summarized in the table below.
 |===================================================================================================
 
 AMR blocks are defined by three parameters: their bounds, the refinement level in which they reside, and
-the scalar data contained within each block. Cell widths are defined per refinement level, not per block.
+the scalar data contained within each block. The coarsest refinement level starts at 0 and cell widths are defined per refinement level, not per block.
 
 The `method` parameter determines the interpolation method used when sampling the volume. The `current`
 method is expected to find the finest refinement level at that cell and interpolate through that "current" 

--- a/chapters/object_types/spatial_fields.txt
+++ b/chapters/object_types/spatial_fields.txt
@@ -14,16 +14,16 @@ created with
 ANARISpatialField anariNewSpatialField(ANARIDevice, const char *subtype);
 ....
 
-[[object_types_spatial_field_amr]]
-==== Adaptive Mesh Refinement (AMR)
+[[object_types_spatial_field_block_structured_amr]]
+==== Block Structured AMR (Adaptive Mesh Refinement)
 
-Extension `KHR_SPATIAL_FIELD_AMR`
+Extension `KHR_SPATIAL_FIELD_BLOCK_STRUCTURED_AMR`
 
-Adaptive Mesh Refinement (AMR) spatial fields are created by passing the subtype
-string `amr` to <<object_types_spatial_field, `anariNewSpatialField`>>. The
-parameters understood by AMR spatial fields are summarized in the table below.
+Block Structured AMR spatial fields are created by passing the subtype
+string `blockStructuredAmr` to <<object_types_spatial_field, `anariNewSpatialField`>>. The
+parameters understood by Block Structured AMR spatial fields are summarized in the table below.
 
-.Configuration parameters for AMR spatial fields.
+.Configuration parameters for Block Structured AMR spatial fields.
 [cols="<2,<3,>,<4",options="header,unbreakable"]
 |===================================================================================================
 | Name            | Type                    | Default   | Description
@@ -35,7 +35,7 @@ parameters understood by AMR spatial fields are summarized in the table below.
 | refinementRatio |`ARRAY1D` of `UINT32`    | | array of refinement ratios relative to the previous level, for levels > 0
 |===================================================================================================
 
-The AMR block scheme used by this extension is based on the
+The Block Structured AMR block scheme used by this extension is based on the
 Berger-Oliger-Collela scheme which is also used by other toolkits and libraries
 like VTK. The following structure is adopted for this scheme:
 
@@ -45,7 +45,7 @@ like VTK. The following structure is adopted for this scheme:
   the same level
 * Grid cells are never partially refined
 
-AMR blocks are defined by three parameters: their start index, the refinement
+Block Structured AMR blocks are defined by three parameters: their start index, the refinement
 level in which they reside, and the scalar data contained within each block. The
 end index of a block can be deduced from its start index and its size (via the
 `ARRAY3D`).

--- a/chapters/object_types/spatial_fields.txt
+++ b/chapters/object_types/spatial_fields.txt
@@ -109,3 +109,37 @@ the the index order of the cells is the same as their VTK counterparts
 `cell.index` cooresponds to the Offsets array and `index` to the Connectivity
 array of (current, not legacy) `vtkCellArray`.
 ====
+
+[[object_types_spatial_field_amr]]
+==== Adaptive Mesh Refinement 
+
+Extension `KHR_SPATIAL_FIELD_AMR`
+
+Adaptive Mesh Refinement (AMR) spatial fields are created by passing the subtype string
+`amr` to <<object_types_spatial_field, `anariNewSpatialField`>>. The parameters
+understood by AMR spatial fields are summarized in the table below.
+
+.Configuration parameters for AMR spatial fields.
+[cols="<,<2,>,<5",options="header,unbreakable"]
+|===================================================================================================
+| Name         | Type                     | Default   | Description
+| block.data   |`ARRAY1D` of `ARRAY3D` of `FLOAT32` | | array of 3D arrays containing the scalar voxel data 
+| gridOrigin   |`FLOAT32_VEC3`            | (0, 0, 0) | origin of the grid in object-space
+| gridSpacing  |`FLOAT32_VEC3`            | (1, 1, 1) | size of the grid cells in object-space
+| method       |`STRING`                  | `current` | sampling method, possible values are: `current`, `finest`, `octant` 
+| cellWidth    |`ARRAY1D` of `FLOAT32`    | | array of each level's cell width 
+| block.bounds |`ARRAY1D` of `INT32_BOX3` | | array of grid sizes, in voxels, for each AMR block 
+| block.level  |`ARRAY1D` of `INT32`      | | array of each block's refinement level 
+|===================================================================================================
+
+AMR blocks are defined by three parameters: their bounds, the refinement level in which they reside, and
+the scalar data contained within each block. Cell widths are defined per refinement level, not per block.
+
+The `method` parameter determines the interpolation method used when sampling the volume. The `current`
+method is expected to find the finest refinement level at that cell and interpolate through that "current" 
+level. The `finest` method is expected to interpolate at the closest existing cell in the volume-wide 
+finest refinement level regardless of the sample cell's level. Lastly, the `octant` method is expected to 
+interpolate through all available refinement levels at that cell.
+
+Applications which set unknown values for `method` will result in the default being used.
+

--- a/chapters/object_types/spatial_fields.txt
+++ b/chapters/object_types/spatial_fields.txt
@@ -133,7 +133,8 @@ understood by AMR spatial fields are summarized in the table below.
 |===================================================================================================
 
 AMR blocks are defined by three parameters: their bounds, the refinement level in which they reside, and
-the scalar data contained within each block. The coarsest refinement level starts at 0 and cell widths are defined per refinement level, not per block.
+the scalar data contained within each block. The coarsest refinement level starts at 0 and cell widths are 
+defined per refinement level, not per block.
 
 The `method` parameter determines the interpolation method used when sampling the volume. The `current`
 method is expected to find the finest refinement level at that cell and interpolate through that "current" 

--- a/chapters/object_types/spatial_fields.txt
+++ b/chapters/object_types/spatial_fields.txt
@@ -126,21 +126,27 @@ understood by AMR spatial fields are summarized in the table below.
 | block.data   |`ARRAY1D` of `ARRAY3D` of `FLOAT32` | | array of 3D arrays containing the scalar voxel data 
 | gridOrigin   |`FLOAT32_VEC3`            | (0, 0, 0) | origin of the grid in object-space
 | gridSpacing  |`FLOAT32_VEC3`            | (1, 1, 1) | size of the grid cells in object-space
-| method       |`STRING`                  | `current` | sampling method, possible values are: `current`, `finest`, `octant` 
+| method       |`STRING`                  | `default` | sampling method
 | cellWidth    |`ARRAY1D` of `FLOAT32`    | | array of each level's cell width 
 | block.bounds |`ARRAY1D` of `INT32_BOX3` | | array of grid sizes, in voxels, for each AMR block 
 | block.level  |`ARRAY1D` of `INT32`      | | array of each block's refinement level 
 |===================================================================================================
 
+The AMR block scheme used by this extension is based on the Berger-Oliger-Collela scheme which is also 
+used by other toolkits and libraries like VTK. The following structure is adopted for this scheme:
+
+* All grids are Cartesian
+* Grids at the same level do not overlap
+* The refinement ratios between adjacent levels are integer and uniform within the same level
+* Grid cells are never partially refined
+
 AMR blocks are defined by three parameters: their bounds, the refinement level in which they reside, and
 the scalar data contained within each block. The coarsest refinement level starts at 0 and cell widths are 
 defined per refinement level, not per block.
 
-The `method` parameter determines the interpolation method used when sampling the volume. The `current`
-method is expected to find the finest refinement level at that cell and interpolate through that "current" 
-level. The `finest` method is expected to interpolate at the closest existing cell in the volume-wide 
-finest refinement level regardless of the sample cell's level. Lastly, the `octant` method is expected to 
-interpolate through all available refinement levels at that cell.
+The `method` parameter determines the interpolation method used when sampling the volume. The `default`
+method uses the back-end's default interpolation technique. Refer to the back-end's documentation for
+details on the default interpolation technique used and other interpolation methods, if any, it supports.
 
 Applications which set unknown values for `method` will result in the default being used.
 


### PR DESCRIPTION
See [AMR Spatial Field Implementation](https://gitlab.kitware.com/griffin28/vtk/-/blob/anari-0.4.0/Rendering/ANARI/vtkAnariAMRVolumeMapperNode.cxx?ref_type=heads) for a concrete example implementing this proposed AMR Spatial Field extension.