### PR TITLE
Bool

### DIFF
--- a/chapters/type_table.txt
+++ b/chapters/type_table.txt
@@ -28,8 +28,8 @@
 |void pointer
 
 |`BOOL`
-|`int32_t`
-|boolean represented as int32_t
+|`uint8_t`
+|boolean represented as uint8_t
 
 |`FUNCTION_POINTER`
 |`void(*)(void)`


### PR DESCRIPTION
As discussed in the WG we like to change the size of `ANARI_BOOL` in the next revision to be 1byte from the current 4byte, which is compatible to `bool` with most C++ compilers.