### PR TITLE
add uniform instance attributes

### DIFF
--- a/chapters/api_concepts.txt
+++ b/chapters/api_concepts.txt
@@ -832,12 +832,12 @@ themselves be thread safe as they can be called on any thread.
 Attributes are quantities that are passed between objects during
 rendering. Attributes are identified by strings.
 
-Surface attributes are passed from <<Geometry, geometries>> to
-<<Material, materials>> and <<Sampler, samplers>>. Attributes are either
-set explicitly by user-provided data as array parameters (and may be
+Surface attributes are passed from <<Geometry, geometries>> and <<Instance,
+instances>> to <<Material, materials>> and <<Sampler, samplers>>. Attributes are
+either set explicitly by user-provided data as array parameters (and may be
 interpolated in a geometry-specific way) or implicitly by the surface.
-Unspecified (components of) attributes default to zero for the first
-three components and to one for the fourth component.
+Unspecified (components of) attributes default to zero for the first three
+components and to one for the fourth component.
 
 .Attributes
 [cols="<,<,<3",options="header",]

--- a/chapters/object_types/instances.txt
+++ b/chapters/object_types/instances.txt
@@ -21,14 +21,23 @@ transform definitions.
 .<<api_concepts_parameters, Parameters>> understood by instances.
 [cols="<3,<4,>3,<14",options="header,unbreakable"]
 |===================================================================================================
-| Name      | Type         |                                       Default | Description
-| group     |`GROUP`       |                                               | <<Group>> to be instanced, required
-| transform |`FLOAT32_MAT4`| \((1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1)) | world-space transformation matrix for all attached objects
-| id        |`UINT32`      |         -1u | <<frame_channels, extension `KHR_FRAME_CHANNEL_INSTANCE_ID`>>, optional user Id, for frame <<frame_channels, channel `instanceId`>>
+| Name       | Type         |                                       Default | Description
+| group      |`GROUP`       |                                               | <<Group>> to be instanced, required
+| transform  |`FLOAT32_MAT4`| \((1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1)) | world-space transformation matrix for all attached objects
+| id         |`UINT32`      |                                           -1u | <<frame_channels, extension `KHR_FRAME_CHANNEL_INSTANCE_ID`>>, optional user Id, for frame <<frame_channels, channel `instanceId`>>
+| color      |`FLOAT32_VEC4`|                                               | uniform color attribute
+| attribute0 |`FLOAT32_VEC4`|                                               | uniform attribute0
+| attribute1 |`FLOAT32_VEC4`|                                               | uniform attribute1
+| attribute2 |`FLOAT32_VEC4`|                                               | uniform attribute2
+| attribute3 |`FLOAT32_VEC4`|                                               | uniform attribute3
 |===================================================================================================
 
 The matrix `transform` represents an affine transformation which is applied to
 homogeneous coordinates.
+
+The uniform attribute parameters apply to all objects contained in the instance
+and have a lower precedence than attribute values found in objects within the
+instance when both are present.
 
 [NOTE]
 .Note


### PR DESCRIPTION
This is primarily motivated by `hdAnari` (now in the SDK), where instances can have overriding primavars (aka attributes).

Note that this is very different from #101 as this is at the attribute level and not changing the definition of `ANARISurface` objects themselves (i.e. material/geometry binding).