### PR TITLE
Clarification of normal maps for physically based material

### DIFF
--- a/chapters/object_types/materials.txt
+++ b/chapters/object_types/materials.txt
@@ -108,6 +108,10 @@ final opacity is determied by `alphaMode`:
   value is greater than or equal to `alphaCutoff`, otherwise fully
   transparent (opacity treated 0)
 
+The values sampled from samplers `normal` and `clearcoatNormal`
+represent tangent space normals (the first two components are expected
+to be in range `[-1, 1]` and the third component is expected to be in
+range `[0, 1]`).
 
 [NOTE]
 .Note
@@ -115,11 +119,11 @@ final opacity is determied by `alphaMode`:
 To use the glTF `metallicRoughnessTexture` create two samplers with the
 same `image` array and a "swizzle" `outTransform` for `roughness`.
 
-The normal maps `normal` and `clearcoatNormal` typically use an
-<<Image2D>> sampler with `image` array element type `FIXED8_VEC3` or
-`FIXED8_VEC4`. The glTF `scale` parameter of normal maps should be
-factored into the `outTransform` of the corresponding <<Sampler,
-sampler>>.
+The normal maps `normal` and `clearcoatNormal` typically use an <<Image2D>>
+sampler with `image` array element type `UFIXED8_VEC3` with a transformation
+from range `[0, 1]` to range `[-1, 1]` via `outTransform`, computing `2.0 *
+texel - 1.0` per channel. The glTF `scale` parameter of normal maps should be
+factored into the `outTransform` of the corresponding <<Sampler, sampler>>.
 
 Similarly, glTF parameters `emissiveStrength` and `emissiveFactor`
 should be factored into `emissive` (or `outTransform` if `emissive` is


### PR DESCRIPTION
Mentions the expected format of the sampled value, which is used directly as normal. This means apps typically need to setup a proper `outTransform` (with the usual `UFIXED` textures; not needed for exotic `FLOAT` or `FIXED` textures).