### PR TITLE
Remove broken and ineffective check

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -24,9 +24,6 @@ jobs:
     if: "${{ github.event_name == 'push' }}"
     needs: build-docs
     steps:
-      - run: |
-          test -n "github.secrets.ANARI_REGISTRY_TOKEN"
-        name: Check if ANARI_REGISTRY_TOKEN is defined
       - uses: actions/checkout@v4
         with:
           repository: ${{ github.repository_owner }}/ANARI-Registry.git


### PR DESCRIPTION
The variable is not even escaped so the condition always evaluates to true...
Good news is that the checkout action correctly complains on missing token.