### PR TITLE
Fixed typo

### DIFF
--- a/chapters/object_types/volumes.txt
+++ b/chapters/object_types/volumes.txt
@@ -37,7 +37,7 @@ The 1D transfer function volume is created by passing the subtype string
 | valueRange       |`FLOAT32_BOX1` / `FLOAT64_BOX1` |  [0, 1] | sampled values of `value` are clamped to this range
 | color            |`FLOAT32_VEC4` / `FLOAT32_VEC3` / `ARRAY1D` of <<Color>>| (1.0, 1.0, 1.0, 1.0)  | color to which the sampled values are mapped to
 | opacity          |`FLOAT32` / `ARRAY1D` of `FLOAT32`|   1.0 | opacity to which the sampled values are mapped to
-| unitDistance     |`FLOAT32`                       |     1.0 | distance after which a 'opacity' fraction of light traverling through the volume is absorbed
+| unitDistance     |`FLOAT32`                       |     1.0 | distance after which a 'opacity' fraction of light traveling through the volume is absorbed
 |===================================================================================================
 
 [NOTE]


### PR DESCRIPTION
Fixed misspelling in the `unitDistance` parameter description.