### PR TITLE
KHR_VOLUME_TRANSFER_FUNCTION2D Extension

### DIFF
--- a/anspec.txt
+++ b/anspec.txt
@@ -45,5 +45,7 @@ include::appendices/extension_index.txt[]
 
 include::appendices/volume_algorithm.txt[]
 
+include::appendices/tf2d_algorithm.txt[]
+
 include::appendices/credits.txt[]
 

--- a/appendices/tf2d_algorithm.txt
+++ b/appendices/tf2d_algorithm.txt
@@ -1,0 +1,52 @@
+// Copyright 2023 The Khronos Group Inc.
+// SPDX-License-Identifier: CC-BY-4.0  
+
+[appendix]
+[[transferFunction2D_lookupTable]]
+== Example Code for Creating a TransferFunction2D LookupTable (Informative)
+
+The following is an illustrative example of a `transferFunction2D` implementation for generating a lookup table. 
+While implementations are not required to match this code exactly, it serves as a reference for the intended 
+design and structure of the lookup table. Developers may adapt the logic, data mappings, or visualization strategies 
+based on the specific needs of their volume rendering pipeline or scientific dataset.
+
+[source]
+....
+anari::Array2D CreateLookupTable(const Volume &volume)
+{
+    std::vector<int> scalars = getScalarValues(volume);
+    std::vector<int> grads = getGradients(volume);
+
+    auto minScalarIt = std::min_element(scalars.begin(), scalars.end());
+    auto maxScalarIt = std::max_element(scalars.begin(), scalars.end());
+    int minScalar = *minScalarIt;
+    int maxScalar = *maxScalarIt;
+    int width = maxScalar - minScalar + 1;
+
+    auto minGradIt = std::min_element(grads.begin(), grads.end());
+    auto maxGradIt = std::max_element(grads.begin(), grads.end());
+    int minGrad = *minGradIt;
+    int maxGrad = *maxGradIt;
+    int height = maxGrad - minGrad + 1;
+
+    std::vector<vec4> lookupTableVector(width * height);
+
+    for (int j = minGrad; j <= maxGrad; ++j) {
+        for (int i = minScalar; i <= maxScalar; ++i) {
+            float red = static_cast<float>(i * j);
+            float green = red * 0.4f;
+            float blue = 0.25f * static_cast<float>(j);
+            float alpha = static_cast<float>(i * j) / static_cast<float>(grads.size());
+
+            vec4 color{red, green, blue, alpha};
+            int x = i - minScalar;
+            int y = j - minGrad;
+            lookupTableVector[y * width + x] = color;
+        }
+    }
+
+    auto lookupTable = anari::newArray2D(device, lookupTableVector.data(), width, height);
+    return lookupTable;
+}
+....
+

--- a/chapters/object_types/volumes.txt
+++ b/chapters/object_types/volumes.txt
@@ -1,5 +1,5 @@
 // Copyright 2023 The Khronos Group Inc.
-// SPDX-License-Identifier: CC-BY-4.0  
+// SPDX-License-Identifier: CC-BY-4.0
 
 [[object_types_volume]]
 === Volume
@@ -77,3 +77,27 @@ surface. Implementations may limit opacity to a value slightly smaller than one.
 A possible implementation of a rendering algorithm for this volume type is given
 in <<transferFunction1D_algorithm>>.
 ====
+
+[[object_types_volume_transfer_function2d]]
+==== TransferFunction2D
+
+Extension `KHR_VOLUME_TRANSFER_FUNCTION2D`
+
+A 2D transfer function uses two separate scalar fields to determine the color and opacity of the
+sampled `value`. This allows for a more nuanced and detailed visualization of volume data compared
+to 1D transfer functions. The 2D transfer function volume is created by passing the subtype string
+`transferFunction2D` to <<object_types_volume, `anariNewVolume`>>. It supports the following parameters:
+
+.<<api_concepts_parameters, Parameters>> understood by the transferFunction2D volume.
+[cols="<3,<5,>4,<7",options="header,unbreakable"]
+|===================================================================================================
+| Name             | Type                           | Default | Description
+| value            |`SPATIAL_FIELD`                 |         | <<object_types_spatial_field, Spatial field>> used for the scalar values of the volume
+| lookupTable      |`SAMPLER` of `Image2D`          |         | two separate scalar fields are represented by the image width and height
+| unitDistance     |`FLOAT32`                       |     1.0 | distance after which a 'opacity' fraction of light traverling through the volume is absorbed
+|===================================================================================================
+
+The `lookupTable` maps the sampled spatial field `value` to color and opacity for two separate scalar
+fields. Typically, the image width (X-axis) represents the sampled data value and the image height (Y-axis)
+represents the gradient magnitude. Clamping and iterpolation values can be viewed and set directly on the
+`lookupTable` through the <<object_types_sampler_image2D>> parameters.

--- a/chapters/object_types/volumes.txt
+++ b/chapters/object_types/volumes.txt
@@ -94,7 +94,7 @@ to 1D transfer functions. The 2D transfer function volume is created by passing 
 | Name             | Type                           | Default | Description
 | value            |`SPATIAL_FIELD`                 |         | <<object_types_spatial_field, Spatial field>> used for the scalar values of the volume
 | valueRange       |`FLOAT32_BOX1` / `FLOAT64_BOX1` |  [0, 1] | sampled values of `value` are clamped to this range
-| lookupTable      |ARRAY2D of <<Color>>            |         | two separate scalar fields are represented by the image width and height
+| lookupTable      |ARRAY2D of <<Color>>            |         | two separate scalar fields are represented by the image width and height (see appendix for additional details)
 | unitDistance     |`FLOAT32`                       |     1.0 | distance after which a 'opacity' fraction of light traverling through the volume is absorbed
 |===================================================================================================
 

--- a/chapters/object_types/volumes.txt
+++ b/chapters/object_types/volumes.txt
@@ -93,11 +93,12 @@ to 1D transfer functions. The 2D transfer function volume is created by passing 
 |===================================================================================================
 | Name             | Type                           | Default | Description
 | value            |`SPATIAL_FIELD`                 |         | <<object_types_spatial_field, Spatial field>> used for the scalar values of the volume
-| lookupTable      |`SAMPLER` of `Image2D`          |         | two separate scalar fields are represented by the image width and height
+| valueRange       |`FLOAT32_BOX1` / `FLOAT64_BOX1` |  [0, 1] | sampled values of `value` are clamped to this range
+| lookupTable      |ARRAY2D of <<Color>>            |         | two separate scalar fields are represented by the image width and height
 | unitDistance     |`FLOAT32`                       |     1.0 | distance after which a 'opacity' fraction of light traverling through the volume is absorbed
 |===================================================================================================
 
-The `lookupTable` maps the sampled spatial field `value` to color and opacity for two separate scalar
-fields. Typically, the image width (X-axis) represents the sampled data value and the image height (Y-axis)
-represents the gradient magnitude. Clamping and iterpolation values can be viewed and set directly on the
-`lookupTable` through the <<object_types_sampler_image2D>> parameters.
+The `lookupTable` maps the scalar `value` to color and opacity for two separate scalar
+fields. Typically, the image width (X-axis) represents the scalar `value` clamped to 
+`valueRange` and the image height (Y-axis) is derived from the scalar `value` which
+,in most cases, represents the gradient magnitude.


### PR DESCRIPTION
Resolves #69. Adds 2D transfer function for volumes.

References:
1. [VTK GPU Volume Mapper](https://www.kitware.com/2d-transfer-function-support-in-gpuvolumemapper/)
2. [VTK Test Example](https://gitlab.kitware.com/vtk/vtk/blob/master/Rendering/Volume/Testing/Cxx/TestGPURayCastTransfer2D.cxx)
3. [TomViz Application](https://www.kitware.com/main/wp-content/uploads/2017/09/volume_TF2d_tooth.mp4?_=1) using 2D Transfer Function 