### PR TITLE
More edits, spelling

### DIFF
--- a/appendices/extension_index.txt
+++ b/appendices/extension_index.txt
@@ -28,10 +28,10 @@
 * <<object_types_geometry_cylinder, `KHR_GEOMETRY_CYLINDER`>>: `cylinder` geometry subtype is supported
 * <<object_types_geometry_isosurface, `KHR_GEOMETRY_ISOSURFACE`>>: `isosurface` geometry subtype is supported
 * <<object_types_geometry_quad, `KHR_GEOMETRY_QUAD`>>: `quad` geometry subtype is supported
-* <<extension_geometry_quad_motion_deformation, `KHR_GEOMETRY_QUAD_MOTION_DEFORMATION`>>: `quad` geometry subtype supports deformation mortion blur
+* <<extension_geometry_quad_motion_deformation, `KHR_GEOMETRY_QUAD_MOTION_DEFORMATION`>>: `quad` geometry subtype supports deformation motion blur
 * <<object_types_geometry_sphere, `KHR_GEOMETRY_SPHERE`>>: `sphere` geometry subtype is supported
 * <<object_types_geometry_triangle, `KHR_GEOMETRY_TRIANGLE`>>: `triangle` geometry subtype is supported
-* <<extension_geometry_triangle_motion_deformation, `KHR_GEOMETRY_TRIANGLE_MOTION_DEFORMATION`>>: `triangle` geometry subtype supports deformation mortion blur
+* <<extension_geometry_triangle_motion_deformation, `KHR_GEOMETRY_TRIANGLE_MOTION_DEFORMATION`>>: `triangle` geometry subtype supports deformation motion blur
 * <<object_types_instance_transform, `KHR_INSTANCE_TRANSFORM`>>: basic `transform` instance subtype is supported
 * <<extension_instance_transform_array, `KHR_INSTANCE_TRANSFORM_ARRAY`>>: the basic `transform` instance subtype supports matrix arrays
 * <<object_types_instance_motion_transform, `KHR_INSTANCE_MOTION_TRANSFORM`>>: `motionTransform` instance subtype and instance transformation motion blur is supported

--- a/chapters/api_concepts.txt
+++ b/chapters/api_concepts.txt
@@ -5,7 +5,7 @@
 == Common API Concepts
 
 This section describes concepts common to all object types for creation,
-parameterization, and property queries.
+parametrization, and property queries.
 
 [[api_concepts_thread_safety]]
 === Thread Safety, Asynchronous Operations
@@ -223,7 +223,7 @@ void anariUnsetParameter(ANARIDevice, ANARIObject);
 include::type_table.txt[]
 |===================================================================================================
 
-Floating point number (data types with `FLOAT`) layout and behaviour are as specified in <<ieee-754>>.
+Floating point number (data types with `FLOAT`) layout and behavior are as specified in <<ieee-754>>.
 
 [[color]]
 ==== Color

--- a/chapters/api_design_choices.txt
+++ b/chapters/api_design_choices.txt
@@ -31,7 +31,7 @@ header and front-end library.
 
 
 [[api_choices_objects]]
-=== Opaque Objects, Parameterization, and Properties
+=== Opaque Objects, Parametrization, and Properties
 
 The ANARI API is designed to encapsulate scene data and rendering operations
 as opaque object handles using string-value pairs to parameterize them. This
@@ -102,13 +102,13 @@ appendix.
 ANARI is designed to be compatible with applications which are distributed
 across multiple processes which may reside on multiple machines. The following
 extensions specify the semantics and required networking to enable rendering
-in distriuted applications.
+in distributed applications.
 
 [NOTE]
 .Note
 ====
 Distributed rendering define semantics and rules for ANARI usage within
-distributed _applications_. Some devices _may_ use distirbuted rendering
+distributed _applications_. Some devices _may_ use distributed rendering
 resources behind the API of single-process applications, which is already
 covered by normal ANARI API usage and does not require additional specification.
 ====
@@ -154,7 +154,7 @@ This extension introduces the following additional parameters:
 [cols="<3,<2,^3,<6",options="header,unbreakable"]
 |=============================================================================================
 | Name            | Type          | Default        | Description
-| mpiCommunicator |`VOID_POINTER` |`MPI_COMM_WORLD`| The MPI communicator which the device should treat as the MPI world.
+| mpiCommunicator |`VOID_POINTER` |`MPI_COMM_WORLD`| the MPI communicator which the device should treat as the MPI world
 |=============================================================================================
 
 [NOTE]

--- a/chapters/introduction.txt
+++ b/chapters/introduction.txt
@@ -39,7 +39,7 @@ more general functionality must be obtained through other APIs or
 applications which use ANARI.
 
 Domains which leverage 3D graphics have diverse rendering needs involving
-tradeoffs among quality, speed, and scalability to available hardware resources.
+trade-offs among quality, speed, and scalability to available hardware resources.
 It is typical for 3D applications to use both visual and quantitative
 rendering techniques to satisfy user demands. Furthermore, it is common for an
 application to need rendering from local CPU or GPU hardware, with parallel

--- a/chapters/object_types/cameras.txt
+++ b/chapters/object_types/cameras.txt
@@ -61,7 +61,7 @@ rendering, which is enabled by setting `stereoMode` and
 | motion.transform   |`ARRAY1D` of `FLOAT32_MAT4`     |            | uniformly distributed world-space transformations
 | motion.scale       |`ARRAY1D` of `FLOAT32_VEC3`     |            | uniformly distributed scale, overridden by `motion.transform`
 | motion.rotation    |`ARRAY1D` of `FLOAT32_QUAT_IJKW`|            | uniformly distributed quaternion rotation, overridden by `motion.transform`
-| motion.translation |`ARRAY1D` of `FLOAT32_VEC3`     |            | uniformly distributed transformlation, overridden by `motion.transform`
+| motion.translation |`ARRAY1D` of `FLOAT32_VEC3`     |            | uniformly distributed translation, overridden by `motion.transform`
 | time               |`FLOAT32_BOX1`                  |     [0, 1] | time associated with first and last key in `motion.pass:[*]` arrays
 |===================================================================================================
 

--- a/chapters/object_types/geometries.txt
+++ b/chapters/object_types/geometries.txt
@@ -97,7 +97,7 @@ Extension `KHR_GEOMETRY_CURVE`
 A geometry consisting of multiple curves is created by calling
 <<object_types_geometry, `anariNewGeometry`>> with type string `curve`. The vertices
 of the curve(s) are connected by linear, round segments (i.e., cones or
-clinders). The parameters defining this geometry are listed in the table
+cylinders). The parameters defining this geometry are listed in the table
 below.
 
 [NOTE]
@@ -124,7 +124,7 @@ them procedurally such that the curve segments are perfectly round.
 
 Parameter `vertex.position` must be set and contain at least two
 elements to yield a valid curve geometry. If no `primitive.index` is
-given, then a single curve is assumed, conneting all vertices.
+given, then a single curve is assumed, connecting all vertices.
 
 All `primitive.pass:[*]` arrays must be at least as large as (explicitly set or
 implicitly derived) `primitive.index`. All `vertex.pass:[*]` arrays must be
@@ -256,7 +256,7 @@ device limit `geometryMaxIndex`>>.
 
 The `faceVarying.pass:[*]` attributes map unique values to each (implicitly or
 explicitly) indexed primitive vertices, where each vertex takes a unique value
-per-primitive that uses it. Each primitive associates vertex attribues values
+per-primitive that uses it. Each primitive associates vertex attributes values
 from the attribute array using the formula `4 * primID + {0, 1, 2, 3}`.
 
 Face-varying attributes take precedence over vertex attributes when both arrays
@@ -376,7 +376,7 @@ device limit `geometryMaxIndex`>>.
 
 The `faceVarying.pass:[*]` attributes map unique values to each (implicitly or
 explicitly) indexed primitive vertices, where each vertex takes a unique value
-per-primitive that uses it. Each primitive associates vertex attribues values
+per-primitive that uses it. Each primitive associates vertex attributes values
 from the attribute array using the formula `3 * primID + {0, 1, 2}`.
 
 Face-varying attributes take precedence over vertex attributes when both arrays

--- a/chapters/object_types/instances.txt
+++ b/chapters/object_types/instances.txt
@@ -14,7 +14,7 @@ ANARIInstance anariNewInstance(ANARIDevice, const char *subtype);
 ....
 
 All instances take a <<Group>> representing all the objects which share the
-instances world-space transform. They also always take a generic `FLOAT32_MAT4`
+instance's world-space transform. They also always take a generic `FLOAT32_MAT4`
 transform which serves as a fall back but may be overridden by subtype specific
 transform definitions.
 
@@ -48,13 +48,6 @@ memory. Implementations are free to always treat the last row (4th, 8th, 12th
 and 16th float) as being (0, 0, 0, 1).
 ====
 
-.<<api_concepts_object_properties, Properties>> queryable on an instance.
-[cols="<,<,<5",options="header,unbreakable"]
-|===================================================================================================
-| Name     | Type         | Description
-| bounds   |`FLOAT32_BOX3`| axis-aligned bounding box in world-space (excluding the lights)
-|===================================================================================================
-
 [NOTE]
 .Note
 ====
@@ -63,6 +56,13 @@ basic parameters listed above, it is recommend that the `transform` parameter
 should always be set in addition to any subtype specific transform parameters.
 ====
 
+
+.<<api_concepts_object_properties, Properties>> queryable on an instance.
+[cols="<,<,<5",options="header,unbreakable"]
+|===================================================================================================
+| Name     | Type         | Description
+| bounds   |`FLOAT32_BOX3`| axis-aligned bounding box in world-space (excluding the lights)
+|===================================================================================================
 
 [[object_types_instance_transform]]
 ==== Transform
@@ -83,7 +83,7 @@ object per-transform.
 [cols="<2,<4,<10",options="header,unbreakable"]
 |==========================================================================================================
 | Name      | Type                       | Description
-| transform |`ARRAY1D` of `FLOAT32_MAT4` | array of matrices, instantiating `group` once per matrix
+| transform |`ARRAY1D` of `FLOAT32_MAT4` | array of matrices, instantiating `group` once per element
 | id        |`ARRAY1D` of `UINT32`       | <<frame_channels, extension `KHR_FRAME_CHANNEL_INSTANCE_ID`>>, optional user Id, for frame <<frame_channels, channel `instanceId`>>
 |==========================================================================================================
 

--- a/chapters/object_types/lights.txt
+++ b/chapters/object_types/lights.txt
@@ -70,10 +70,10 @@ increasing the angular diameter will result in softer shadows (when soft
 shadows are supported by the implementation), but the overall brightness
 in the scene stays roughly the same. With `radiance` however, increasing
 the angular diameter will also result in a brighter illumination in the
-scene. Using `radiance` is only meaninful if `angularDiameter` is larger
+scene. Using `radiance` is only meaningful if `angularDiameter` is larger
 than zero (otherwise the directional light is not emitting any light).
 
-Using a direction light with an angular diameter is a good approximation
+Using a directional light with an angular diameter is a good approximation
 for sunlight: the apparent size of the sun is about 0.53° or 0.00925
 rad.
 ==================
@@ -120,7 +120,7 @@ outside). It is created by passing the subtype string `point` to
 point light supports the following special parameters:
 
 .Additional <<api_concepts_parameters, parameters>> understood by the point <<object_types_light, light>>.
-[cols="<2,<3,>2,<13",options="header,unbreakable"]
+[cols="<21,<28,>19,<125",options="header,unbreakable"]
 |===================================================================================================
 | Name      | Type         |    Default | Description
 | position  |`FLOAT32_VEC3`|  (0, 0, 0) | the position of the point light
@@ -149,7 +149,7 @@ differs in behavior when the `radius` is changing: With `intensity` or
 shadows are supported by the implementation), but the overall brightness
 in the scene stays roughly the same. With `radiance` however, increasing
 the radius will also result in a brighter illumination in the scene.
-Using `radiance` is only meaninful if `radius` is larger than zero
+Using `radiance` is only meaningful if `radius` is larger than zero
 (otherwise the point light is not emitting any light).
 
 Since power is the integral of intensity over the sphere of directions,
@@ -164,10 +164,11 @@ constant factor of 4{pi} in brightness.
 Extension `KHR_LIGHT_QUAD`
 
 The quad light is a planar, procedural area light source, a parallelogram,
-emitting uniformly on one side into the half-space. It is created by passing the
-subtype string `quad` to <<object_types_light, `anariNewLight`>>. In addition to
-the <<object_types_light, general parameters>> understood by all lights, the
-quad light supports the following special parameters:
+emitting uniformly either on one side into the half-space, or on both sides.
+It is created by passing the subtype string `quad` to <<object_types_light,
+`anariNewLight`>>. In addition to the <<object_types_light, general parameters>>
+understood by all lights, the quad light supports the following special
+parameters:
 
 .Additional <<api_concepts_parameters, parameters>> understood by the quad <<object_types_light, light>>.
 [cols="<5,<3,>2,<11",options="header,unbreakable"]
@@ -178,12 +179,13 @@ quad light supports the following special parameters:
 | edge2        |`FLOAT32_VEC3`|  (0, 1, 0) | vector to the other adjacent vertex
 | intensity    |`FLOAT32`     |          1 | the overall amount of light emitted by the light in a
                                              direction, in W/sr
-| power        |`FLOAT32`     |          1 | the overall amount of light energy emitted, in W;
-                                             `intensity` takes precedence if also specified
-| radiance     |`FLOAT32`     |          1 | the amount of light
-                                             emitted by a point on the light source in a direction,
-                                             in W/sr/m^2^; `intensity` (or `power`) takes
-                                             precedence if also specified
+| power        |`FLOAT32`     |            | alternative specification of the
+					     brightness (if `intensity` is not explicitly set):
+                                             the overall amount of light energy emitted, in W
+| radiance     |`FLOAT32`     |            | alternative specification of the brightness (if neither
+					     `intensity` nor `power` is not explicitly set): the
+					     amount of light emitted by a point on the light source
+					     in a direction, in W/sr/m^2^
 //TODO| map          |`TEXTURE`     |            | factor for `color`?
 | side         |`STRING`      |     `front`| side into which light is emitted;
                                              possible values: `front`, `back`, `both`
@@ -192,6 +194,23 @@ quad light supports the following special parameters:
                                              illumination; values are assumed to be uniformly
                                              distributed
 |===================================================================================================
+
+The precedence order is `intensity`, `power`, `radiance`: the first (in
+this ordering) explicitly set parameter is used.
+
+[NOTE]
+.Note
+==================
+The main way to specify the brightness of the quad light via `intensity`
+and its alternative specifications via `power` or `radiance` differs in
+behavior when area (determined by `edge1` and `edge2`) is changing: With
+`intensity` or `power`, increasing the area will result in softer
+shadows (when soft shadows are supported by the implementation), but the
+overall brightness in the scene stays roughly the same. With `radiance`
+however, increasing the area will also result in a brighter illumination
+in the scene.
+==================
+
 
 Measured light sources (IES, EULUMDAT, …) are supported by providing an
 `intensityDistribution` {array} to modulate the intensity
@@ -240,18 +259,19 @@ an area light and thus has a cosine falloff.
 | falloffAngle |`FLOAT32`     |        0.1 | size (angle in radians) of the region between the rim
                                              (of the illumination cone) and full intensity;
                                              should be smaller than half of `openingAngle`
-| intensity    |`FLOAT32`     |          1 | the overall amount of light emitted by the light in a
-                                             direction, in W/sr
-| power        |`FLOAT32`     |          1 | the overall amount of light energy emitted, in W;
-                                            `intensity` takes precedence if also specified
 | radius       |`FLOAT32`     |          0 | the (outer) size of the ring, the radius of a disk
                                              with normal `direction`
 | innerRadius  |`FLOAT32`     |          0 | in combination with `radius` turns the disk into a
                                              ring; must be smaller than `radius`
-| radiance     |`FLOAT32`     |          1 | the amount of light
-                                             emitted by a point on the light source in a direction,
-                                             in W/sr/m^2^; `intensity` (or `power`) takes
-                                             precedence if also specified
+| intensity    |`FLOAT32`     |          1 | the overall amount of light emitted by the light in a
+                                             direction, in W/sr
+| power        |`FLOAT32`     |            | alternative specification of the brightness (if
+					     `intensity` is not explicitly set): the overall amount
+					     of light energy emitted, in W
+| radiance     |`FLOAT32`     |            | alternative specification of the brightness (if neither
+					     `intensity` nor `power` is explicitly set): the amount
+					     of light emitted by a point on the light source in a
+					     direction, in W/sr/m^2^
 | intensityDistribution |`ARRAY1D` / `ARRAY2D` of `FLOAT32`| | luminous intensity distribution for
                                              photometric lights; can be 2D for asymmetric
                                              illumination; values are assumed to be uniformly
@@ -261,9 +281,23 @@ an area light and thus has a cosine falloff.
                                             `intensityDistribution` is asymmetric)
 |===================================================================================================
 
-Setting the radius to a value greater than zero will result in soft shadows when
-the renderer uses stochastic sampling. Additionally setting the inner radius
-will result in a ring instead of a disk emitting the light.
+The precedence order is `intensity`, `power`, `radiance`: the first (in
+this ordering) explicitly set parameter is used.
+
+[NOTE]
+.Note
+==================
+The main way to specify the brightness of the ring light via `intensity`
+and its alternative specifications via `power` or `radiance` differs in
+behavior when area (determined by `radius` and `innerRadius`) is
+changing: With `intensity` or `power`, increasing the area will result
+in softer shadows (when soft shadows are supported by the
+implementation), but the overall brightness in the scene stays roughly
+the same. With `radiance` however, increasing the area will also result
+in a brighter illumination in the scene.
+Using `radiance` is only meaningful if `radius` is larger than zero
+(otherwise the point light is not emitting any light).
+==================
 
 Measured light sources (IES, EULUMDAT, …) are supported by providing an
 `intensityDistribution` {array} to modulate the intensity

--- a/chapters/object_types/materials.txt
+++ b/chapters/object_types/materials.txt
@@ -40,7 +40,7 @@ independent of the viewing direction. The matte material supports
 
 If `color` is of type `ANARI_SAMPLER` or `ANARI_STRING`, the fourth
 component of the value fetched from a sampler or attribute is multiplied
-with the opacity value. The final opacity is determied by `alphaMode`:
+with the opacity value. The final opacity is determined by `alphaMode`:
 
 * `opaque`: fully opaque (opacity treated as 1)
 * `blend`: partial opacity
@@ -100,7 +100,7 @@ https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materi
 If `baseColor` is of type `ANARI_SAMPLER` or `ANARI_STRING` and
 `alphaMode` is not `opaque`, the fourth component of the value fetched
 from a sampler or attribute is multiplied with the `opacity` value. The
-final opacity is determied by `alphaMode`:
+final opacity is determined by `alphaMode`:
 
 * `opaque`: fully opaque (opacity treated as 1)
 * `blend`: partial opacity

--- a/chapters/object_types/samplers.txt
+++ b/chapters/object_types/samplers.txt
@@ -159,7 +159,7 @@ The primitive sampler samples an `Array1D` at integer
 coordinates based on the `primitiveId` surface attribute.
 It is created by calling <<object_types_sampler,
 `anariNewSampler`>> with subtype string `primitive`.
-The `inOffset` parameter value is added to `primitiveID` before sampling.
+The `inOffset` parameter value is added to `primitiveId` before sampling.
 
 .<<api_concepts_parameters, Parameters>> understood by the primitive sampler.
 [cols="<,<2,>,<5",options="header,unbreakable"]

--- a/chapters/object_types/spatial_fields.txt
+++ b/chapters/object_types/spatial_fields.txt
@@ -69,13 +69,13 @@ the table below.
 [cols="<,<2,>,<5",options="header,unbreakable"]
 |===================================================================================================
 | Name    | Type                |    Default | Description
-| data    |`ARRAY1D` of `UINT8` |            | NanoVDB grid, as a binary blob.
+| data    |`ARRAY1D` of `UINT8` |            | NanoVDB grid, as a binary blob
 | filter  |`STRING`             |    `linear`| filter used for reconstructing the field,
                                                possible values: `nearest`, `linear`, `cubic`
 |===================================================================================================
 
 The `data` parameter content is expected to be a single NanoVDB grid, as read from a NanoVDB file or constructed by the NanoVDB API.
-The spatial field extent is implicitely defined in the grid header.
+The spatial field extent is implicitly defined in the grid header.
 
 The device must support NanoVDB grids with major version 32.
 
@@ -99,13 +99,13 @@ below.
 | vertex.position |`ARRAY1D` of `FLOAT32_VEC3`                                             | array of vertex positions
 | vertex.data     |`ARRAY1D` of `UFIXED8` / `FIXED16` / `UFIXED16` / `FLOAT32` / `FLOAT64` | array of values at vertices
 | index           |`ARRAY1D` of `UINT32`                                                   | array of indices into the `vertex.pass:[*]` arrays that form cells
-| cell.data       |`ARRAY1D` of `UFIXED8` / `FIXED16` / `UFIXED16` / `FLOAT32` / `FLOAT64` | array of values in cells
+| cell.data       |`ARRAY1D` of `UFIXED8` / `FIXED16` / `UFIXED16` / `FLOAT32` / `FLOAT64` | alternative specification of the values (if `vertex.data` is not explicitly set): array of values in cells
 | cell.type       |`ARRAY1D` of `UINT8`                                                    | array of cell types, where 10 encodes tetrahedral, 12 hexahedral, 13 wedge, and 14 pyramidal cells
 | cell.index      |`ARRAY1D` of `UINT32`                                                   | array of indices into the `index` array, specifying the first (index of the) vertex of each cell
 |===================================================================================================
 
 Sampled cell values can be specified either per-vertex (via `vertex.data`) or
-per-cell (via `cell.data`). If both arrays are set, `vertex.data` takes
+per-cell (via `cell.data`). If both arrays are explicitly set, `vertex.data` takes
 precedence.
 
 Each cell is formed by a consecutive group of indices from `index` into the
@@ -129,10 +129,10 @@ counterclockwise, then the top vertex.
 [NOTE]
 .Note
 ====
-The unstructured spatial field is modelled after and thus compatible to
+The unstructured spatial field is modeled after and thus compatible to
 `vtkUnstructuredGrid`: `cell.type` values are the same as VTK cell types, and
 the the index order of the cells is the same as their VTK counterparts
 (`VTK_TETRA`, `VTK_HEXAHEDRON`, `VTK_WEDGE`, and `VTK_PYRAMID`). The arrays
-`cell.index` cooresponds to the Offsets array and `index` to the Connectivity
+`cell.index` corresponds to the Offsets array and `index` to the Connectivity
 array of (current, not legacy) `vtkCellArray`.
 ====

--- a/chapters/rendering_frames.txt
+++ b/chapters/rendering_frames.txt
@@ -47,7 +47,7 @@ being rendered are valid before rendering occurs.
 ====
 
 [[anariDiscardFrame]]
-Applications can signal that an in-flight frame should be cancelled if possible
+Applications can signal that an in-flight frame should be canceled if possible
 using
 
 [source,cpp]
@@ -56,7 +56,7 @@ void anariDiscardFrame(ANARIDevice, ANARIFrame);
 ....
 
 This call is not required to block until the frame completes, rather it only
-signals to the implementation to attempt cancelling the currently rendered
+signals to the implementation to attempt canceling the currently rendered
 frame instead of going all the way to completion. The contents of a mapped
 frame which has been discarded is undefined.
 


### PR DESCRIPTION
- brightness parameter precendence clarifications for quad and ring light (similar as for directional, point and spot light before)