### PR TITLE
Add new `clampToBorder` for samplers' `wrapMode`

### DIFF
--- a/appendices/changelog.txt
+++ b/appendices/changelog.txt
@@ -6,7 +6,7 @@
 == Changes in Version 1.2 (Informative)
 
 === New Extensions
-* <<extension_sampler_image_clamp_to_border, `KHR_SAMPLER_IMAGE_CLAMP_TO_BORDER`>>:
+* <<extension_sampler_imagexd_clamp_to_border, `KHR_SAMPLER_IMAGExD_CLAMP_TO_BORDER`>>:
   - `image1D` sampler `wrapMode` supports `clampToBorder`
   - `image2D` sampler `wrapMode1` and `wrapMode2` support `clampToBorder`
   - `image3D` sampler `wrapMode1`, `wrapMode2` and `wrapMode3` support `clampToBorder`

--- a/appendices/changelog.txt
+++ b/appendices/changelog.txt
@@ -2,7 +2,16 @@
 // SPDX-License-Identifier: CC-BY-4.0
 
 [appendix]
-[[changelog]]
+[[changelog12]]
+== Changes in Version 1.2 (Informative)
+
+=== Changes to Core Functionality and Extensions
+
+* Added `clampToBorder` to `wrapMode1`, `wrapMode2`, `wrapMode3` to <<Image1D, image1d>>,
+<<Image2D, image2d>> and <<Image3D, image3d>> samplers.
+
+[appendix]
+[[changelog11]]
 == Changes in Version 1.1 (Informative)
 
 === New Extensions

--- a/appendices/changelog.txt
+++ b/appendices/changelog.txt
@@ -6,9 +6,10 @@
 == Changes in Version 1.2 (Informative)
 
 === New Extensions
-* <<object_types_sampler_image1D, `KHR_SAMPLER_CLAMP_TO_BORDER`>>: `image1D` supports `clampToBorder` for parameters `wrapMode`
-* <<object_types_sampler_image2D, `KHR_SAMPLER_CLAMP_TO_BORDER`>>: `image2D` supports `clampToBorder` for parameters `wrapMode1`, `wrapMode2`
-* <<object_types_sampler_image3D, `KHR_SAMPLER_CLAMP_TO_BORDER`>>: `image3D` supports `clampToBorder` for parameters `wrapMode1`, `wrapMode2`, `wrapMode3`
+* <<extension_sampler_image_clamp_to_border, `KHR_SAMPLER_IMAGE_CLAMP_TO_BORDER`>>:
+  - `image1D` sampler `wrapMode` supports `clampToBorder`
+  - `image2D` sampler `wrapMode1` and `wrapMode2` support `clampToBorder`
+  - `image3D` sampler `wrapMode1`, `wrapMode2` and `wrapMode3` support `clampToBorder`
 
 === Changes to Core Functionality and Extensions
 

--- a/appendices/changelog.txt
+++ b/appendices/changelog.txt
@@ -5,6 +5,11 @@
 [[changelog12]]
 == Changes in Version 1.2 (Informative)
 
+=== New Extensions
+* <<object_types_sampler_image1D, `KHR_SAMPLER_CLAMP_TO_BORDER`>>: `image1D` supports `clampToBorder` for parameters `wrapMode`
+* <<object_types_sampler_image2D, `KHR_SAMPLER_CLAMP_TO_BORDER`>>: `image2D` supports `clampToBorder` for parameters `wrapMode1`, `wrapMode2`
+* <<object_types_sampler_image3D, `KHR_SAMPLER_CLAMP_TO_BORDER`>>: `image3D` supports `clampToBorder` for parameters `wrapMode1`, `wrapMode2`, `wrapMode3`
+
 === Changes to Core Functionality and Extensions
 
 * Added `clampToBorder` to `wrapMode1`, `wrapMode2`, `wrapMode3` to <<Image1D, image1d>>,

--- a/appendices/extension_index.txt
+++ b/appendices/extension_index.txt
@@ -55,6 +55,10 @@
 * <<extension_sampler_clamp_to_border_image2d, `KHR_SAMPLER_CLAMP_TO_BORDER`>>: `image2D` sampler wrapMode1, wrapMode2 support clampToBorder
 * <<object_types_sampler_image3D, `KHR_SAMPLER_IMAGE3D`>>: `image3D` sampler subtype is supported
 * <<extension_sampler_clamp_to_border_image3d, `KHR_SAMPLER_CLAMP_TO_BORDER`>>: `image3D` sampler wrapMode1, wrapMode2, wrapMode3 support clampToBorder
+* <<extension_sampler_image_clamp_to_border, `KHR_SAMPLER_IMAGE_CLAMP_TO_BORDER`>>:
+  - `image1D` sampler `wrapMode` supports `clampToBorder`
+  - `image2D` sampler `wrapMode1` and `wrapMode2` support `clampToBorder`
+  - `image3D` sampler `wrapMode1`, `wrapMode2` and `wrapMode3` support `clampToBorder`
 * <<object_types_sampler_primitive, `KHR_SAMPLER_PRIMITIVE`>>: `primitive` sampler subtype is supported
 * <<object_types_sampler_transform, `KHR_SAMPLER_TRANSFORM`>>: `transform` sampler subtype is supported
 * <<object_types_spatial_field_nanovdb, `KHR_SPATIAL_FIELD_NANOVDB`>>: `nanovdb` spatial field subtype is supported

--- a/appendices/extension_index.txt
+++ b/appendices/extension_index.txt
@@ -50,8 +50,11 @@
 * <<extension_renderer, `KHR_RENDERER_BACKGROUND_IMAGE`>>:  the renderer supports a background image
 * <<extension_renderer, `KHR_RENDERER_DENOISE`>>:  the renderer supports denoising
 * <<object_types_sampler_image1D, `KHR_SAMPLER_IMAGE1D`>>: `image1D` sampler subtype is supported
+* <<extension_sampler_clamp_to_border_image1d, `KHR_SAMPLER_CLAMP_TO_BORDER`>>: `image1D` sampler wrapMode supports clampToBorder
 * <<object_types_sampler_image2D, `KHR_SAMPLER_IMAGE2D`>>: `image2D` sampler subtype is supported
+* <<extension_sampler_clamp_to_border_image2d, `KHR_SAMPLER_CLAMP_TO_BORDER`>>: `image2D` sampler wrapMode1, wrapMode2 support clampToBorder
 * <<object_types_sampler_image3D, `KHR_SAMPLER_IMAGE3D`>>: `image3D` sampler subtype is supported
+* <<extension_sampler_clamp_to_border_image3d, `KHR_SAMPLER_CLAMP_TO_BORDER`>>: `image3D` sampler wrapMode1, wrapMode2, wrapMode3 support clampToBorder
 * <<object_types_sampler_primitive, `KHR_SAMPLER_PRIMITIVE`>>: `primitive` sampler subtype is supported
 * <<object_types_sampler_transform, `KHR_SAMPLER_TRANSFORM`>>: `transform` sampler subtype is supported
 * <<object_types_spatial_field_nanovdb, `KHR_SPATIAL_FIELD_NANOVDB`>>: `nanovdb` spatial field subtype is supported

--- a/appendices/extension_index.txt
+++ b/appendices/extension_index.txt
@@ -50,15 +50,12 @@
 * <<extension_renderer, `KHR_RENDERER_BACKGROUND_IMAGE`>>:  the renderer supports a background image
 * <<extension_renderer, `KHR_RENDERER_DENOISE`>>:  the renderer supports denoising
 * <<object_types_sampler_image1D, `KHR_SAMPLER_IMAGE1D`>>: `image1D` sampler subtype is supported
-* <<extension_sampler_clamp_to_border_image1d, `KHR_SAMPLER_CLAMP_TO_BORDER`>>: `image1D` sampler wrapMode supports clampToBorder
 * <<object_types_sampler_image2D, `KHR_SAMPLER_IMAGE2D`>>: `image2D` sampler subtype is supported
-* <<extension_sampler_clamp_to_border_image2d, `KHR_SAMPLER_CLAMP_TO_BORDER`>>: `image2D` sampler wrapMode1, wrapMode2 support clampToBorder
 * <<object_types_sampler_image3D, `KHR_SAMPLER_IMAGE3D`>>: `image3D` sampler subtype is supported
-* <<extension_sampler_clamp_to_border_image3d, `KHR_SAMPLER_CLAMP_TO_BORDER`>>: `image3D` sampler wrapMode1, wrapMode2, wrapMode3 support clampToBorder
-* <<extension_sampler_image_clamp_to_border, `KHR_SAMPLER_IMAGE_CLAMP_TO_BORDER`>>:
-  - `image1D` sampler `wrapMode` supports `clampToBorder`
-  - `image2D` sampler `wrapMode1` and `wrapMode2` support `clampToBorder`
-  - `image3D` sampler `wrapMode1`, `wrapMode2` and `wrapMode3` support `clampToBorder`
+* <<extension_sampler_imagexd_clamp_to_border, `KHR_SAMPLER_IMAGE_CLAMPxD_TO_BORDER`>>:
+  - <<extension_sampler_image1d_clamp_to_border, `image1D`>> sampler `wrapMode` supports `clampToBorder`
+  - <<extension_sampler_image2d_clamp_to_border, `image2D`>> sampler `wrapMode1` and `wrapMode2` support `clampToBorder`
+  - <<extension_sampler_image3d_clamp_to_border, `image3D`>> sampler `wrapMode1`, `wrapMode2` and `wrapMode3` support `clampToBorder`
 * <<object_types_sampler_primitive, `KHR_SAMPLER_PRIMITIVE`>>: `primitive` sampler subtype is supported
 * <<object_types_sampler_transform, `KHR_SAMPLER_TRANSFORM`>>: `transform` sampler subtype is supported
 * <<object_types_spatial_field_nanovdb, `KHR_SPATIAL_FIELD_NANOVDB`>>: `nanovdb` spatial field subtype is supported

--- a/chapters/object_types/samplers.txt
+++ b/chapters/object_types/samplers.txt
@@ -44,8 +44,8 @@ A one dimensional image sampler is created by calling <<object_types_sampler,
 `anariNewSampler`>> with subtype string `image1D`. It accepts the following
 parameters.
 
-[[extension_sampler_clamp_to_border_image1d]]
-The `KHR_SAMPLER_CLAMP_TO_BORDER` extension adds the `clampToBorder` mode to `wrapMode`.
+[[extension_sampler_image_clamp_to_border_image1d]]
+The `KHR_SAMPLER_IMAGE_CLAMP_TO_BORDER` extension adds the `clampToBorder` mode to `wrapMode`.
 
 .<<api_concepts_parameters, Parameters>> understood by the 1D image sampler.
 [cols="<16,<16,>13,<53",options="header,unbreakable"]
@@ -56,7 +56,7 @@ The `KHR_SAMPLER_CLAMP_TO_BORDER` extension adds the `clampToBorder` mode to `wr
 | inOffset | `FLOAT32_VEC4` | (0, 0, 0, 0) | offset added to input transform result
 | image | `ARRAY1D` of <<Color>> |  | array backing the sampler
 | filter | `STRING` | `linear` | filter of the sampler, possible values: `nearest`, `linear`
-| wrapMode | `STRING` | `clampToEdge` | wrap mode of the sampler, possible values: `clampToBorder` (extension `KHR_SAMPLER_CLAMP_TO_BORDER`), `clampToEdge`, `repeat`, `mirrorRepeat`
+| wrapMode | `STRING` | `clampToEdge` | wrap mode of the sampler, possible values: `clampToBorder` (extension `KHR_SAMPLER_IMAGE_CLAMP_TO_BORDER`), `clampToEdge`, `repeat`, `mirrorRepeat`
 | borderColor | `FLOAT32_VEC4` | (0, 0, 0, 0) | border color used when wrapMode is `clampToBorder`
 |===================================================================================================
 
@@ -85,8 +85,8 @@ Extension `KHR_SAMPLER_IMAGE2D`
 A two dimensional image sampler is created by calling <<object_types_sampler,
 `anariNewSampler`>> with subtype string `image2D`. It accepts the following parameters.
 
-[[extension_sampler_clamp_to_border_image2d]]
-The `KHR_SAMPLER_CLAMP_TO_BORDER` extension adds the `clampToBorder` mode to `wrapMode1` and `wrapMode2`.
+[[extension_sampler_image_clamp_to_border_image2d]]
+The `KHR_SAMPLER_IMAGE_CLAMP_TO_BORDER` extension adds the `clampToBorder` mode to `wrapMode1` and `wrapMode2`.
 
 .<<api_concepts_parameters, Parameters>> understood by the 2D image sampler.
 [cols="<16,<16,>13,<53",options="header,unbreakable"]
@@ -97,8 +97,8 @@ The `KHR_SAMPLER_CLAMP_TO_BORDER` extension adds the `clampToBorder` mode to `wr
 | inOffset | `FLOAT32_VEC4` | (0, 0, 0, 0) | offset added to input transform result
 | image | `ARRAY2D` of <<Color>> / `FIXED8_VEC3` / `FIXED8_VEC4`|  | array backing the sampler
 | filter | `STRING` | `linear` | filter of the sampler, possible values: `nearest`, `linear`
-| wrapMode1 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 1st dimension, possible values: `clampToBorder` (extension `KHR_SAMPLER_CLAMP_TO_BORDER`), `clampToEdge`, `repeat`, `mirrorRepeat`
-| wrapMode2 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 2nd dimension, possible values: `clampToBorder` (extension `KHR_SAMPLER_CLAMP_TO_BORDER`), `clampToEdge`, `repeat`, `mirrorRepeat`
+| wrapMode1 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 1st dimension, possible values: `clampToBorder` (extension `KHR_SAMPLER_IMAGE_CLAMP_TO_BORDER`), `clampToEdge`, `repeat`, `mirrorRepeat`
+| wrapMode2 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 2nd dimension, possible values: `clampToBorder` (extension `KHR_SAMPLER_IMAGE_CLAMP_TO_BORDER`), `clampToEdge`, `repeat`, `mirrorRepeat`
 | borderColor | `FLOAT32_VEC4` | (0, 0, 0, 0) | border color used when wrapMode is `clampToBorder`
 |===================================================================================================
 
@@ -127,8 +127,8 @@ Extension `KHR_SAMPLER_IMAGE3D`
 A three dimensional image sampler is created by calling <<object_types_sampler,
 `anariNewSampler`>> with subtype string `image3D`. It accepts the following parameters.
 
-[[extension_sampler_clamp_to_border_image3d]]
-The `KHR_SAMPLER_CLAMP_TO_BORDER` extension adds the `clampToBorder` mode to `wrapMode1`, `wrapMode2` and `wrapMode3`.
+[[extension_sampler_image_clamp_to_border_image3d]]
+The `KHR_SAMPLER_IMAGE_CLAMP_TO_BORDER` extension adds the `clampToBorder` mode to `wrapMode1`, `wrapMode2` and `wrapMode3`.
 
 .<<api_concepts_parameters, Parameters>> understood by the 3D image sampler.
 [cols="<16,<16,>13,<53",options="header,unbreakable"]
@@ -139,9 +139,9 @@ The `KHR_SAMPLER_CLAMP_TO_BORDER` extension adds the `clampToBorder` mode to `wr
 | inOffset | `FLOAT32_VEC4` | (0, 0, 0, 0) | offset added to input transform result
 | image | `ARRAY3D` of <<Color>> |  | array backing the sampler
 | filter | `STRING` | `linear` | filter of the sampler, possible values: `nearest`, `linear`
-| wrapMode1 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 1st dimension, possible values: `clampToBorder` (extension `KHR_SAMPLER_CLAMP_TO_BORDER`), `clampToEdge`, `repeat`, `mirrorRepeat`
-| wrapMode2 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 2nd dimension, possible values: `clampToBorder` (extension `KHR_SAMPLER_CLAMP_TO_BORDER`), `clampToEdge`, `repeat`, `mirrorRepeat`
-| wrapMode3 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 3rd dimension, possible values: `clampToBorder` (extension `KHR_SAMPLER_CLAMP_TO_BORDER`), `clampToEdge`, `repeat`, `mirrorRepeat`
+| wrapMode1 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 1st dimension, possible values: `clampToBorder` (extension `KHR_SAMPLER_IMAGE_CLAMP_TO_BORDER`), `clampToEdge`, `repeat`, `mirrorRepeat`
+| wrapMode2 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 2nd dimension, possible values: `clampToBorder` (extension `KHR_SAMPLER_IMAGE_CLAMP_TO_BORDER`), `clampToEdge`, `repeat`, `mirrorRepeat`
+| wrapMode3 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 3rd dimension, possible values: `clampToBorder` (extension `KHR_SAMPLER_IMAGE_CLAMP_TO_BORDER`), `clampToEdge`, `repeat`, `mirrorRepeat`
 | borderColor | `FLOAT32_VEC4` | (0, 0, 0, 0) | border color used when wrapMode is `clampToBorder`
 |===================================================================================================
 

--- a/chapters/object_types/samplers.txt
+++ b/chapters/object_types/samplers.txt
@@ -53,7 +53,8 @@ parameters.
 | inOffset | `FLOAT32_VEC4` | (0, 0, 0, 0) | offset added to input transform result
 | image | `ARRAY1D` of <<Color>> |  | array backing the sampler
 | filter | `STRING` | `linear` | filter of the sampler, possible values: `nearest`, `linear`
-| wrapMode | `STRING` | `clampToEdge` | wrap mode of the sampler, possible values: `clampToEdge`, `repeat`, `mirrorRepeat`
+| wrapMode | `STRING` | `clampToEdge` | wrap mode of the sampler, possible values: `clampToBorder`, `clampToEdge`, `repeat`, `mirrorRepeat`
+| borderColor | `FLOAT32_VEC4` | (0, 0, 0, 0) | border color used when wrapMode is `clampToBorder`
 |===================================================================================================
 
 The attribute values indicated by `inAttribute` are first multiplied by the
@@ -90,8 +91,9 @@ A two dimensional image sampler is created by calling <<object_types_sampler,
 | inOffset | `FLOAT32_VEC4` | (0, 0, 0, 0) | offset added to input transform result
 | image | `ARRAY2D` of <<Color>> / `FIXED8_VEC3` / `FIXED8_VEC4`|  | array backing the sampler
 | filter | `STRING` | `linear` | filter of the sampler, possible values: `nearest`, `linear`
-| wrapMode1 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 1st dimension, possible values: `clampToEdge`, `repeat`, `mirrorRepeat`
-| wrapMode2 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 2nd dimension, possible values: `clampToEdge`, `repeat`, `mirrorRepeat`
+| wrapMode1 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 1st dimension, possible values: `clampToBorder`, `clampToEdge`, `repeat`, `mirrorRepeat`
+| wrapMode2 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 2nd dimension, possible values: `clampToBorder`, `clampToEdge`, `repeat`, `mirrorRepeat`
+| borderColor | `FLOAT32_VEC4` | (0, 0, 0, 0) | border color used when wrapMode is `clampToBorder`
 |===================================================================================================
 
 The attribute values indicated by `inAttribute` are first multiplied by the
@@ -128,9 +130,10 @@ A three dimensional image sampler is created by calling <<object_types_sampler,
 | inOffset | `FLOAT32_VEC4` | (0, 0, 0, 0) | offset added to input transform result
 | image | `ARRAY3D` of <<Color>> |  | array backing the sampler
 | filter | `STRING` | `linear` | filter of the sampler, possible values: `nearest`, `linear`
-| wrapMode1 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 1st dimension, possible values: `clampToEdge`, `repeat`, `mirrorRepeat`
-| wrapMode2 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 2nd dimension, possible values: `clampToEdge`, `repeat`, `mirrorRepeat`
-| wrapMode3 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 3rd dimension, possible values: `clampToEdge`, `repeat`, `mirrorRepeat`
+| wrapMode1 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 1st dimension, possible values: `clampToBorder`, `clampToEdge`, `repeat`, `mirrorRepeat`
+| wrapMode2 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 2nd dimension, possible values: `clampToBorder`, `clampToEdge`, `repeat`, `mirrorRepeat`
+| wrapMode3 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 3rd dimension, possible values: `clampToBorder`, `clampToEdge`, `repeat`, `mirrorRepeat`
+| borderColor | `FLOAT32_VEC4` | (0, 0, 0, 0) | border color used when wrapMode is `clampToBorder`
 |===================================================================================================
 
 The attribute values indicated by `inAttribute` are first multiplied by the

--- a/chapters/object_types/samplers.txt
+++ b/chapters/object_types/samplers.txt
@@ -44,6 +44,9 @@ A one dimensional image sampler is created by calling <<object_types_sampler,
 `anariNewSampler`>> with subtype string `image1D`. It accepts the following
 parameters.
 
+[[extension_sampler_clamp_to_border_image1d]]
+The `KHR_SAMPLER_CLAMP_TO_BORDER` extension adds the `clampToBorder` mode to `wrapMode`.
+
 .<<api_concepts_parameters, Parameters>> understood by the 1D image sampler.
 [cols="<16,<16,>13,<53",options="header,unbreakable"]
 |===================================================================================================
@@ -53,7 +56,7 @@ parameters.
 | inOffset | `FLOAT32_VEC4` | (0, 0, 0, 0) | offset added to input transform result
 | image | `ARRAY1D` of <<Color>> |  | array backing the sampler
 | filter | `STRING` | `linear` | filter of the sampler, possible values: `nearest`, `linear`
-| wrapMode | `STRING` | `clampToEdge` | wrap mode of the sampler, possible values: `clampToBorder`, `clampToEdge`, `repeat`, `mirrorRepeat`
+| wrapMode | `STRING` | `clampToEdge` | wrap mode of the sampler, possible values: `clampToBorder` (extension `KHR_SAMPLER_CLAMP_TO_BORDER`), `clampToEdge`, `repeat`, `mirrorRepeat`
 | borderColor | `FLOAT32_VEC4` | (0, 0, 0, 0) | border color used when wrapMode is `clampToBorder`
 |===================================================================================================
 
@@ -82,6 +85,9 @@ Extension `KHR_SAMPLER_IMAGE2D`
 A two dimensional image sampler is created by calling <<object_types_sampler,
 `anariNewSampler`>> with subtype string `image2D`. It accepts the following parameters.
 
+[[extension_sampler_clamp_to_border_image2d]]
+The `KHR_SAMPLER_CLAMP_TO_BORDER` extension adds the `clampToBorder` mode to `wrapMode1` and `wrapMode2`.
+
 .<<api_concepts_parameters, Parameters>> understood by the 2D image sampler.
 [cols="<16,<16,>13,<53",options="header,unbreakable"]
 |===================================================================================================
@@ -91,8 +97,8 @@ A two dimensional image sampler is created by calling <<object_types_sampler,
 | inOffset | `FLOAT32_VEC4` | (0, 0, 0, 0) | offset added to input transform result
 | image | `ARRAY2D` of <<Color>> / `FIXED8_VEC3` / `FIXED8_VEC4`|  | array backing the sampler
 | filter | `STRING` | `linear` | filter of the sampler, possible values: `nearest`, `linear`
-| wrapMode1 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 1st dimension, possible values: `clampToBorder`, `clampToEdge`, `repeat`, `mirrorRepeat`
-| wrapMode2 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 2nd dimension, possible values: `clampToBorder`, `clampToEdge`, `repeat`, `mirrorRepeat`
+| wrapMode1 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 1st dimension, possible values: `clampToBorder` (extension `KHR_SAMPLER_CLAMP_TO_BORDER`), `clampToEdge`, `repeat`, `mirrorRepeat`
+| wrapMode2 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 2nd dimension, possible values: `clampToBorder` (extension `KHR_SAMPLER_CLAMP_TO_BORDER`), `clampToEdge`, `repeat`, `mirrorRepeat`
 | borderColor | `FLOAT32_VEC4` | (0, 0, 0, 0) | border color used when wrapMode is `clampToBorder`
 |===================================================================================================
 
@@ -121,6 +127,9 @@ Extension `KHR_SAMPLER_IMAGE3D`
 A three dimensional image sampler is created by calling <<object_types_sampler,
 `anariNewSampler`>> with subtype string `image3D`. It accepts the following parameters.
 
+[[extension_sampler_clamp_to_border_image3d]]
+The `KHR_SAMPLER_CLAMP_TO_BORDER` extension adds the `clampToBorder` mode to `wrapMode1`, `wrapMode2` and `wrapMode3`.
+
 .<<api_concepts_parameters, Parameters>> understood by the 3D image sampler.
 [cols="<16,<16,>13,<53",options="header,unbreakable"]
 |===================================================================================================
@@ -130,9 +139,9 @@ A three dimensional image sampler is created by calling <<object_types_sampler,
 | inOffset | `FLOAT32_VEC4` | (0, 0, 0, 0) | offset added to input transform result
 | image | `ARRAY3D` of <<Color>> |  | array backing the sampler
 | filter | `STRING` | `linear` | filter of the sampler, possible values: `nearest`, `linear`
-| wrapMode1 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 1st dimension, possible values: `clampToBorder`, `clampToEdge`, `repeat`, `mirrorRepeat`
-| wrapMode2 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 2nd dimension, possible values: `clampToBorder`, `clampToEdge`, `repeat`, `mirrorRepeat`
-| wrapMode3 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 3rd dimension, possible values: `clampToBorder`, `clampToEdge`, `repeat`, `mirrorRepeat`
+| wrapMode1 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 1st dimension, possible values: `clampToBorder` (extension `KHR_SAMPLER_CLAMP_TO_BORDER`), `clampToEdge`, `repeat`, `mirrorRepeat`
+| wrapMode2 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 2nd dimension, possible values: `clampToBorder` (extension `KHR_SAMPLER_CLAMP_TO_BORDER`), `clampToEdge`, `repeat`, `mirrorRepeat`
+| wrapMode3 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 3rd dimension, possible values: `clampToBorder` (extension `KHR_SAMPLER_CLAMP_TO_BORDER`), `clampToEdge`, `repeat`, `mirrorRepeat`
 | borderColor | `FLOAT32_VEC4` | (0, 0, 0, 0) | border color used when wrapMode is `clampToBorder`
 |===================================================================================================
 

--- a/chapters/object_types/samplers.txt
+++ b/chapters/object_types/samplers.txt
@@ -44,8 +44,8 @@ A one dimensional image sampler is created by calling <<object_types_sampler,
 `anariNewSampler`>> with subtype string `image1D`. It accepts the following
 parameters.
 
-[[extension_sampler_image_clamp_to_border_image1d]]
-The `KHR_SAMPLER_IMAGE_CLAMP_TO_BORDER` extension adds the `clampToBorder` mode to `wrapMode`.
+[[extension_sampler_image1d_clamp_to_border]]
+The `KHR_SAMPLER_IMAGExD_CLAMP_TO_BORDER` extension adds the `clampToBorder` mode to `wrapMode`.
 
 .<<api_concepts_parameters, Parameters>> understood by the 1D image sampler.
 [cols="<16,<16,>13,<53",options="header,unbreakable"]
@@ -56,8 +56,8 @@ The `KHR_SAMPLER_IMAGE_CLAMP_TO_BORDER` extension adds the `clampToBorder` mode 
 | inOffset | `FLOAT32_VEC4` | (0, 0, 0, 0) | offset added to input transform result
 | image | `ARRAY1D` of <<Color>> |  | array backing the sampler
 | filter | `STRING` | `linear` | filter of the sampler, possible values: `nearest`, `linear`
-| wrapMode | `STRING` | `clampToEdge` | wrap mode of the sampler, possible values: `clampToBorder` (extension `KHR_SAMPLER_IMAGE_CLAMP_TO_BORDER`), `clampToEdge`, `repeat`, `mirrorRepeat`
-| borderColor | `FLOAT32_VEC4` | (0, 0, 0, 0) | border color used when wrapMode is `clampToBorder`
+| wrapMode | `STRING` | `clampToEdge` | wrap mode of the sampler, possible values: `clampToEdge`, `repeat`, `mirrorRepeat`, `clampToBorder` (extension `KHR_SAMPLER_IMAGExD_CLAMP_TO_BORDER`)
+| borderColor | `FLOAT32_VEC4` | (0, 0, 0, 0) | extension `KHR_SAMPLER_IMAGExD_CLAMP_TO_BORDER`, border color used when wrapMode is `clampToBorder`
 |===================================================================================================
 
 The attribute values indicated by `inAttribute` are first multiplied by the
@@ -85,8 +85,8 @@ Extension `KHR_SAMPLER_IMAGE2D`
 A two dimensional image sampler is created by calling <<object_types_sampler,
 `anariNewSampler`>> with subtype string `image2D`. It accepts the following parameters.
 
-[[extension_sampler_image_clamp_to_border_image2d]]
-The `KHR_SAMPLER_IMAGE_CLAMP_TO_BORDER` extension adds the `clampToBorder` mode to `wrapMode1` and `wrapMode2`.
+[[extension_sampler_image2d_clamp_to_border]]
+The `KHR_SAMPLER_IMAGExD_CLAMP_TO_BORDER` extension adds the `clampToBorder` mode to `wrapMode1` and `wrapMode2`.
 
 .<<api_concepts_parameters, Parameters>> understood by the 2D image sampler.
 [cols="<16,<16,>13,<53",options="header,unbreakable"]
@@ -97,9 +97,9 @@ The `KHR_SAMPLER_IMAGE_CLAMP_TO_BORDER` extension adds the `clampToBorder` mode 
 | inOffset | `FLOAT32_VEC4` | (0, 0, 0, 0) | offset added to input transform result
 | image | `ARRAY2D` of <<Color>> / `FIXED8_VEC3` / `FIXED8_VEC4`|  | array backing the sampler
 | filter | `STRING` | `linear` | filter of the sampler, possible values: `nearest`, `linear`
-| wrapMode1 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 1st dimension, possible values: `clampToBorder` (extension `KHR_SAMPLER_IMAGE_CLAMP_TO_BORDER`), `clampToEdge`, `repeat`, `mirrorRepeat`
-| wrapMode2 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 2nd dimension, possible values: `clampToBorder` (extension `KHR_SAMPLER_IMAGE_CLAMP_TO_BORDER`), `clampToEdge`, `repeat`, `mirrorRepeat`
-| borderColor | `FLOAT32_VEC4` | (0, 0, 0, 0) | border color used when wrapMode is `clampToBorder`
+| wrapMode1 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 1st dimension, possible values: `clampToEdge`, `repeat`, `mirrorRepeat`, `clampToBorder` (extension `KHR_SAMPLER_IMAGExD_CLAMP_TO_BORDER`)
+| wrapMode2 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 2nd dimension, possible values: `clampToEdge`, `repeat`, `mirrorRepeat`, `clampToBorder` (extension `KHR_SAMPLER_IMAGExD_CLAMP_TO_BORDER`)
+| borderColor | `FLOAT32_VEC4` | (0, 0, 0, 0) | extension `KHR_SAMPLER_IMAGExD_CLAMP_TO_BORDER`, border color used when wrapMode is `clampToBorder`
 |===================================================================================================
 
 The attribute values indicated by `inAttribute` are first multiplied by the
@@ -127,8 +127,8 @@ Extension `KHR_SAMPLER_IMAGE3D`
 A three dimensional image sampler is created by calling <<object_types_sampler,
 `anariNewSampler`>> with subtype string `image3D`. It accepts the following parameters.
 
-[[extension_sampler_image_clamp_to_border_image3d]]
-The `KHR_SAMPLER_IMAGE_CLAMP_TO_BORDER` extension adds the `clampToBorder` mode to `wrapMode1`, `wrapMode2` and `wrapMode3`.
+[[extension_sampler_image3d_clamp_to_border]]
+The `KHR_SAMPLER_IMAGExD_CLAMP_TO_BORDER` extension adds the `clampToBorder` mode to `wrapMode1`, `wrapMode2` and `wrapMode3`.
 
 .<<api_concepts_parameters, Parameters>> understood by the 3D image sampler.
 [cols="<16,<16,>13,<53",options="header,unbreakable"]
@@ -139,10 +139,10 @@ The `KHR_SAMPLER_IMAGE_CLAMP_TO_BORDER` extension adds the `clampToBorder` mode 
 | inOffset | `FLOAT32_VEC4` | (0, 0, 0, 0) | offset added to input transform result
 | image | `ARRAY3D` of <<Color>> |  | array backing the sampler
 | filter | `STRING` | `linear` | filter of the sampler, possible values: `nearest`, `linear`
-| wrapMode1 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 1st dimension, possible values: `clampToBorder` (extension `KHR_SAMPLER_IMAGE_CLAMP_TO_BORDER`), `clampToEdge`, `repeat`, `mirrorRepeat`
-| wrapMode2 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 2nd dimension, possible values: `clampToBorder` (extension `KHR_SAMPLER_IMAGE_CLAMP_TO_BORDER`), `clampToEdge`, `repeat`, `mirrorRepeat`
-| wrapMode3 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 3rd dimension, possible values: `clampToBorder` (extension `KHR_SAMPLER_IMAGE_CLAMP_TO_BORDER`), `clampToEdge`, `repeat`, `mirrorRepeat`
-| borderColor | `FLOAT32_VEC4` | (0, 0, 0, 0) | border color used when wrapMode is `clampToBorder`
+| wrapMode1 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 1st dimension, possible values: `clampToEdge`, `repeat`, `mirrorRepeat`, `clampToBorder` (extension `KHR_SAMPLER_IMAGExD_CLAMP_TO_BORDER`)
+| wrapMode2 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 2nd dimension, possible values: `clampToEdge`, `repeat`, `mirrorRepeat`, `clampToBorder` (extension `KHR_SAMPLER_IMAGExD_CLAMP_TO_BORDER`)
+| wrapMode3 | `STRING` | `clampToEdge` | wrap mode of the sampler for the 3rd dimension, possible values: `clampToEdge`, `repeat`, `mirrorRepeat`, `clampToBorder` (extension `KHR_SAMPLER_IMAGExD_CLAMP_TO_BORDER`)
+| borderColor | `FLOAT32_VEC4` | (0, 0, 0, 0) | extension `KHR_SAMPLER_IMAGExD_CLAMP_TO_BORDER`, border color used when wrapMode is `clampToBorder`
 |===================================================================================================
 
 The attribute values indicated by `inAttribute` are first multiplied by the


### PR DESCRIPTION
As discussed, here is a proposal to add support for `clampToBorder` to ImageXD samplers.

Default wrapping mode is still `clampToEdge`.
Default `borderColor` is transparent black.

Note that the feature seems to be widely available:
- CUDA (documented as early as 6.5)
- OpenGL, DirectX
- OpenGL ES 3.2 or through the GL_EXT_texture_border_clamp
- Vulkan needs VK_EXT_custom_border_color, seems to be supported by many [devices](https://vulkan.gpuinfo.org/displayextensiondetail.php?extension=VK_EXT_custom_border_color), but it is a [transition-layer extension](https://docs.vulkan.org/guide/latest/extensions/translation_layer_extensions.html)
- Metal (it seems to be missing on older iOS platforms)

Worst case, this is something that should be implementable using programmable hardware.
